### PR TITLE
Create Re-encoding Script

### DIFF
--- a/utils/pi/tools/reencode_h264.py
+++ b/utils/pi/tools/reencode_h264.py
@@ -3,8 +3,11 @@
 import os
 import argparse
 import ffmpeg
+import json
 from pathlib import Path
+
 from pysalmcount import utils
+from pysalmcount.motion_detect_stream import MOTION_VIDS_METADATA_DIR
 
 EXT = '.mp4'
 
@@ -30,7 +33,16 @@ def reencode_h264(filepath):
 def main(args):
     for filename in os.listdir(args.input):
         # Check if metadata file exists
-        # Check if video file is not H264
+        filepath = Path(filename)
+        metadata_path = filepath.parent / MOTION_VIDS_METADATA_DIR / (filepath.stem + '.json')
+        if metadata_path.exists():
+            # Check if video file is not H264
+            with open(str(metadata_path), 'r') as f:
+                metadata_dict = json.load(f)
+
+            metadata = utils.VideoMetadata(**metadata_dict)
+            if metadata.codec_name == 'h264':
+                continue
         # Re-encode video to H264
         gen_metadata(filename)
 

--- a/utils/pi/tools/reencode_h264.py
+++ b/utils/pi/tools/reencode_h264.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+from pysalmcount import utils
+
+def gen_metadata(filename):
+    metadata = utils.get_video_metadata(filename)
+    if metadata is not None:
+        logger.info(f"Metadata for video file {filename}: {metadata}")
+        metadata_filepath = VideoSaver.filename_to_metadata_filepath(Path(filename))
+        logger.info(f"Saving metadata file to harddrive: {str(metadata_filepath)}")
+        with open(str(metadata_filepath), 'w') as f:
+            json.dump(asdict(metadata), f)
+    else:
+        logger.error(f"Could not generate metadata for file: {filename}")
+
+def main(args):
+    for filename in os.listdir(args.input):
+        gen_metadata(filename)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Re-encodes video clips in a folder to H264 and re-generates their metadata.")
+    parser.add_argument("input", help="Input folder")
+    args = parser.parse_args()
+
+    main(args)

--- a/utils/pi/tools/reencode_h264.py
+++ b/utils/pi/tools/reencode_h264.py
@@ -2,7 +2,11 @@
 
 import os
 import argparse
+import ffmpeg
+from pathlib import Path
 from pysalmcount import utils
+
+EXT = '.mp4'
 
 def gen_metadata(filename):
     metadata = utils.get_video_metadata(filename)
@@ -15,8 +19,19 @@ def gen_metadata(filename):
     else:
         logger.error(f"Could not generate metadata for file: {filename}")
 
+def reencode_h264(filepath):
+    input_path = Path(filepath)
+    tmp_filename = input_path.stem + '_tmp' + EXT
+    tmp_out_path = input_path.with_name(tmp_filename)
+    ffmpeg.input(filepath).output(tmp_out_path, vcodec='libx264', movflags='faststart').run()
+
+    # Overwrite old vid file
+
 def main(args):
     for filename in os.listdir(args.input):
+        # Check if metadata file exists
+        # Check if video file is not H264
+        # Re-encode video to H264
         gen_metadata(filename)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Motion video clips already created before #91 will still be in mpeg encoding, so we need to re-encode these old files in the harddrive and re-generate the metadata and update the S3 bucket with the H264 encoding.