### PR TITLE
Complete Re-encode to H264 script and docker compose runnable

### DIFF
--- a/training/pysalmcount/pysalmcount/utils.py
+++ b/training/pysalmcount/pysalmcount/utils.py
@@ -83,4 +83,5 @@ def get_video_metadata(video_filepath: Path) -> Union[None, VideoMetadata]:
 
     except ffmpeg.Error as e:
         logger.error(f"Error occured: {e}")
+        logger.error(f"{e.stderr}")
         return None

--- a/training/pysalmcount/pysalmcount/utils.py
+++ b/training/pysalmcount/pysalmcount/utils.py
@@ -9,6 +9,14 @@ import ffmpeg
 
 from typing import Union
 
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s [%(filename)s:%(lineno)d] - %(message)s',
+)
+
+logger = logging.getLogger(__name__)
+
 @dataclass
 class VideoMetadata:
     duration: float
@@ -46,7 +54,7 @@ def parse_ffmpeg_video_stream_probe(video_stream: dict) -> Union[None, VideoMeta
         )
 
     except Exception as e:
-        logging.error(f"Could not parse video_stream: {video_stream}, error {e}")
+        logger.error(f"Could not parse video_stream: {video_stream}, error {e}")
         return None
 
 
@@ -68,11 +76,11 @@ def get_video_metadata(video_filepath: Path) -> Union[None, VideoMetadata]:
             None,
         )
         if video_stream is None:
-            logging.error(f"No video stream found")
+            logger.error(f"No video stream found")
             return None
 
         return parse_ffmpeg_video_stream_probe(video_stream)
 
     except ffmpeg.Error as e:
-        logging.error(f"Error occured: {e}")
+        logger.error(f"Error occured: {e}")
         return None

--- a/utils/jetson/salmoncount/Dockerfile
+++ b/utils/jetson/salmoncount/Dockerfile
@@ -1,9 +1,10 @@
 FROM ultralytics/ultralytics:latest-jetson-jetpack4
+ARG BRANCH=master
 
 # Install dependencies
 RUN python3 -m pip install -U pip
 
-RUN git clone --depth 1 https://github.com/Salmon-Computer-Vision/salmon-computer-vision.git /tools
+RUN git clone --branch ${BRANCH} --depth 1 https://github.com/Salmon-Computer-Vision/salmon-computer-vision.git /tools
 
 RUN python3 -m pip install /tools/training/pysalmcount
 

--- a/utils/pi/tools/Dockerfile
+++ b/utils/pi/tools/Dockerfile
@@ -1,0 +1,5 @@
+ARG IMAGE_REPO_HOST
+ARG TAG
+FROM ${IMAGE_REPO_HOST}/salmoncounter:${TAG}
+
+COPY reencode_h264.py /app/reencode_h264.py

--- a/utils/pi/tools/Dockerfile
+++ b/utils/pi/tools/Dockerfile
@@ -2,4 +2,7 @@ ARG IMAGE_REPO_HOST
 ARG TAG
 FROM ${IMAGE_REPO_HOST}/salmoncounter:${TAG}
 
+RUN apt-get update && apt-get install -y ffmpeg
+RUN python3 -m pip install ffmpeg-python
+
 COPY reencode_h264.py /app/reencode_h264.py

--- a/utils/pi/tools/README.md
+++ b/utils/pi/tools/README.md
@@ -1,4 +1,4 @@
-Sample `.env` file:
+Sample `.env` file to run with `docker compose`:
 ```
 IMAGE_REPO_HOST=hostname
 TAG=latest-jetson-jetpack4

--- a/utils/pi/tools/README.md
+++ b/utils/pi/tools/README.md
@@ -1,0 +1,7 @@
+Sample `.env` file:
+```
+IMAGE_REPO_HOST=hostname
+TAG=latest-jetson-jetpack4
+DRIVE=/media/hdd
+TARGET_DIR=/media/hdd/TAG/dev/jetson-0/motion_vids/
+```

--- a/utils/pi/tools/docker-compose.yml
+++ b/utils/pi/tools/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  reencode:
+    env_file:
+      - ./.env
+    build: 
+      context: .
+      args:
+        IMAGE_REPO_HOST: ${IMAGE_REPO_HOST}
+        TAG: ${TAG}
+    container_name: reencode
+    volumes:
+      - ${DRIVE}:${DRIVE}
+    entrypoint: /bin/sh
+    command: |
+      -c 'python3 reencode_h264.py ${DRIVE}'

--- a/utils/pi/tools/docker-compose.yml
+++ b/utils/pi/tools/docker-compose.yml
@@ -12,4 +12,4 @@ services:
       - ${DRIVE}:${DRIVE}
     entrypoint: /bin/sh
     command: |
-      -c 'python3 reencode_h264.py ${DRIVE}'
+      -c 'python3 reencode_h264.py ${TARGET_DIR}'

--- a/utils/pi/tools/reencode_h264.py
+++ b/utils/pi/tools/reencode_h264.py
@@ -52,18 +52,30 @@ def main(args):
 
     for filename in os.listdir(input_dir_path):
         filepath = input_dir_path / filename
-        metadata = utils.get_video_metadata(filepath)
+        try:
+            metadata = utils.get_video_metadata(filepath)
+        except Exception as e:
+            logger.error(f'Cannot get metadata of {filepath}. Error: {e}')
+            continue
 
         is_h264 = False
         if metadata.codec_name != 'h264':
             # Re-encode video to H264
-            reencode_h264(filepath, archive_path)
+            try:
+                reencode_h264(filepath, archive_path)
+            except Exception as e:
+                logger.error(f'Cannot re-encode {filepath}. Error: {e}')
+                continue
         else:
             is_h264 = True
 
         metadata_path = metadata_dir / (filepath.stem + '.json')
         if not is_h264 or not metadata_path.exists():
-            gen_metadata(filepath)
+            try:
+                gen_metadata(filepath)
+            except Exception as e:
+                logger.error(f'Cannot generate metadata for {filepath}. Error: {e}')
+                continue
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Re-encodes video clips in a folder to H264 and re-generates their metadata.")

--- a/utils/pi/tools/reencode_h264.py
+++ b/utils/pi/tools/reencode_h264.py
@@ -41,9 +41,13 @@ def main(args):
                 metadata_dict = json.load(f)
 
             metadata = utils.VideoMetadata(**metadata_dict)
+            # Generate metadata of the current vid
+            # Check that new generation is H264
             if metadata.codec_name == 'h264':
                 continue
         # Re-encode video to H264
+
+        # Create metadata if not exists or re-encoded
         gen_metadata(filename)
 
 if __name__ == "__main__":

--- a/utils/pi/tools/reencode_h264.py
+++ b/utils/pi/tools/reencode_h264.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 from pysalmcount import utils
+from pysalmcount.motion_detect_stream import VideoSaver
 from pysalmcount.motion_detect_stream import MOTION_VIDS_METADATA_DIR
 import shutil
 

--- a/utils/pi/tools/reencode_h264.py
+++ b/utils/pi/tools/reencode_h264.py
@@ -8,8 +8,10 @@ from pathlib import Path
 
 from pysalmcount import utils
 from pysalmcount.motion_detect_stream import MOTION_VIDS_METADATA_DIR
+import shutil
 
 EXT = '.mp4'
+ARCHIVE_DIR = 'motion_vids_archive'
 
 def gen_metadata(filename):
     metadata = utils.get_video_metadata(filename)
@@ -22,33 +24,32 @@ def gen_metadata(filename):
     else:
         logger.error(f"Could not generate metadata for file: {filename}")
 
-def reencode_h264(filepath):
-    input_path = Path(filepath)
-    tmp_filename = input_path.stem + '_tmp' + EXT
-    tmp_out_path = input_path.with_name(tmp_filename)
-    ffmpeg.input(filepath).output(tmp_out_path, vcodec='libx264', movflags='faststart').run()
+def reencode_h264(filename: str, archive_dir: str):
+    filepath = Path(filename)
+    archive_path = Path(archive_dir) / filepath.name
+    shutil.move(filepath, archive_path)
 
-    # Overwrite old vid file
+    ffmpeg.input(archive_path).output(filepath, vcodec='libx264', movflags='faststart').run()
 
 def main(args):
+    input_dir_path = Path(args.input)
+    archive_path = input_dir_path.parent / ARCHIVE_DIR
+    archive_path.mkdir(exist_ok=True)
+
     for filename in os.listdir(args.input):
-        # Check if metadata file exists
         filepath = Path(filename)
+        metadata = utils.get_video_metadata(filename)
+
+        is_h264 = False
+        if metadata.codec_name != 'h264':
+            # Re-encode video to H264
+            reencode_h264(filename, archive_path)
+        else:
+            is_h264 = True
+
         metadata_path = filepath.parent / MOTION_VIDS_METADATA_DIR / (filepath.stem + '.json')
-        if metadata_path.exists():
-            # Check if video file is not H264
-            with open(str(metadata_path), 'r') as f:
-                metadata_dict = json.load(f)
-
-            metadata = utils.VideoMetadata(**metadata_dict)
-            # Generate metadata of the current vid
-            # Check that new generation is H264
-            if metadata.codec_name == 'h264':
-                continue
-        # Re-encode video to H264
-
-        # Create metadata if not exists or re-encoded
-        gen_metadata(filename)
+        if not is_h264 or not metadata_path.exists():
+            gen_metadata(filename)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Re-encodes video clips in a folder to H264 and re-generates their metadata.")

--- a/utils/pi/tools/reencode_h264.py
+++ b/utils/pi/tools/reencode_h264.py
@@ -4,53 +4,66 @@ import os
 import argparse
 import ffmpeg
 import json
+import logging
 from pathlib import Path
+from dataclasses import asdict
 
 from pysalmcount import utils
 from pysalmcount.motion_detect_stream import VideoSaver
 from pysalmcount.motion_detect_stream import MOTION_VIDS_METADATA_DIR
 import shutil
 
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s [%(filename)s:%(lineno)d] - %(message)s',
+)
+
+logger = logging.getLogger(__name__)
+
 EXT = '.mp4'
 ARCHIVE_DIR = 'motion_vids_archive'
 
-def gen_metadata(filename):
-    metadata = utils.get_video_metadata(filename)
+def gen_metadata(filepath: Path):
+    metadata = utils.get_video_metadata(filepath)
     if metadata is not None:
-        logger.info(f"Metadata for video file {filename}: {metadata}")
-        metadata_filepath = VideoSaver.filename_to_metadata_filepath(Path(filename))
+        logger.info(f"Metadata for video file {filepath}: {metadata}")
+        metadata_filepath = VideoSaver.filename_to_metadata_filepath(filepath)
         logger.info(f"Saving metadata file to harddrive: {str(metadata_filepath)}")
         with open(str(metadata_filepath), 'w') as f:
             json.dump(asdict(metadata), f)
     else:
-        logger.error(f"Could not generate metadata for file: {filename}")
+        logger.error(f"Could not generate metadata for file: {filepath}")
 
-def reencode_h264(filename: str, archive_dir: str):
-    filepath = Path(filename)
+def reencode_h264(filepath: Path, archive_dir: str):
+    temp_path = filepath.with_name(filepath.stem + '_temp' + filepath.suffix) 
     archive_path = Path(archive_dir) / filepath.name
-    shutil.move(filepath, archive_path)
 
-    ffmpeg.input(archive_path).output(filepath, vcodec='libx264', movflags='faststart').run()
+    ffmpeg.input(str(filepath)).output(str(temp_path), vcodec='libx264', movflags='faststart').run()
+    shutil.move(filepath, archive_path)
+    shutil.move(temp_path, filepath)
 
 def main(args):
     input_dir_path = Path(args.input)
     archive_path = input_dir_path.parent / ARCHIVE_DIR
     archive_path.mkdir(exist_ok=True)
+    metadata_dir = input_dir_path.parent / MOTION_VIDS_METADATA_DIR
+    metadata_dir.mkdir(exist_ok=True)
 
-    for filename in os.listdir(args.input):
-        filepath = Path(filename)
-        metadata = utils.get_video_metadata(filename)
+    for filename in os.listdir(input_dir_path):
+        filepath = input_dir_path / filename
+        metadata = utils.get_video_metadata(filepath)
 
         is_h264 = False
         if metadata.codec_name != 'h264':
             # Re-encode video to H264
-            reencode_h264(filename, archive_path)
+            reencode_h264(filepath, archive_path)
         else:
             is_h264 = True
 
-        metadata_path = filepath.parent / MOTION_VIDS_METADATA_DIR / (filepath.stem + '.json')
+        metadata_path = metadata_dir / (filepath.stem + '.json')
         if not is_h264 or not metadata_path.exists():
-            gen_metadata(filename)
+            gen_metadata(filepath)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Re-encodes video clips in a folder to H264 and re-generates their metadata.")


### PR DESCRIPTION
The main python script is `reencode_h264.py`.

This aims to look into a specified `TARGET_DIR`, list all videos, and re-encode to H264 + generate metadata if necessary.

I created a simple `docker-compose.yml` to build and run using the `salmoncounter` image the Jetsons should already have. I would need to change the target directory when a run completes, however, it's really only a one time deal for each site.

A sample `.env` file for running with `docker compose` is as follows:
```
IMAGE_REPO_HOST=hostname
TAG=dev-jetson-jetpack4
DRIVE=/media/hdd
TARGET_DIR=/media/hdd/TAG/dev/jetson-0/motion_vids/
```