### PR TITLE
Separate Frame Reading in a Different Thread

### DIFF
--- a/training/pysalmcount/pysalmcount/videoloader.py
+++ b/training/pysalmcount/pysalmcount/videoloader.py
@@ -69,7 +69,7 @@ class VideoLoader(DataLoader):
 
         return self.cur_clip
 
-     def _read_frames(self):
+    def _read_frames(self):
         """
         Reads frames from the video capture in a separate thread and stores them in a deque.
         """

--- a/training/pysalmcount/pysalmcount/videoloader.py
+++ b/training/pysalmcount/pysalmcount/videoloader.py
@@ -3,7 +3,7 @@ from .dataloader import DataLoader, Item
 import cv2
 from pathlib import Path
 import logging
-from threading import Thread, Condition
+from threading import Thread
 from queue import Queue
 
 # Set up logging
@@ -31,7 +31,6 @@ class VideoLoader(DataLoader):
 
         buffer_size = buffer_size
         self.frame_buffer = Queue(maxsize=buffer_size)
-        self.buffer_condition = Condition()
         self.thread = None
         self.stop_thread = False
 

--- a/training/tools/run_motion_detect_rtsp.py
+++ b/training/tools/run_motion_detect_rtsp.py
@@ -51,7 +51,7 @@ def main(args):
         input_str = args.rtsp_url
 
     logger.info(input_str)
-    vidloader = vl.VideoLoader([input_str], gstreamer_on=args.gstreamer)
+    vidloader = vl.VideoLoader([input_str], gstreamer_on=args.gstreamer, buffer_size=2*int(args.fps))
 
     logger.info(f"save_prefix: {save_prefix}")
     det = md.MotionDetector(vidloader, site_save_path, save_prefix)

--- a/utils/pi/services/Dockerfiles/Dockerfile-salmonmd-64
+++ b/utils/pi/services/Dockerfiles/Dockerfile-salmonmd-64
@@ -1,10 +1,11 @@
 FROM balenalib/raspberrypi5-python:3.11-bookworm-build
+ARG BRANCH=master
 
 RUN apt-get update && apt-get install -y git ffmpeg python3-opencv
 
 RUN python3 -m pip install -U pip && python3 -m pip install -U ffmpeg-python
 
-RUN git clone --depth 1 https://github.com/Salmon-Computer-Vision/salmon-computer-vision.git /tools
+RUN git clone --branch ${BRANCH} --depth 1 https://github.com/Salmon-Computer-Vision/salmon-computer-vision.git /tools
 
 RUN python3 -m pip install -e /tools/training/pysalmcount
 


### PR DESCRIPTION
Setup RTSP reading and consumption into a producer/consumer pattern. This should fix potential corruption or some frame skipping issues that occur when the frame reading happens at the same time as the motion detection processing.