### PR TITLE
Add Target FPS Specification

### DIFF
--- a/training/pysalmcount/pysalmcount/videoloader.py
+++ b/training/pysalmcount/pysalmcount/videoloader.py
@@ -82,7 +82,7 @@ class VideoLoader(DataLoader):
 
             ret, frame = self.cap.read()
             if ret:
-                if self.target_fps < self.vid_fps && time_elapsed < 1. / self.target_fps:
+                if self.target_fps < self.vid_fps and time_elapsed < 1. / self.target_fps:
                     continue
                 else:
                     prev = time.time()

--- a/training/pysalmcount/pysalmcount/videoloader.py
+++ b/training/pysalmcount/pysalmcount/videoloader.py
@@ -18,7 +18,7 @@ class VideoCaptureError(Exception):
     pass
 
 class VideoLoader(DataLoader):
-    def __init__(self, vid_sources, custom_classes=None, gstreamer_on=False, buffer_size=10):
+    def __init__(self, vid_sources, custom_classes=None, gstreamer_on=False, buffer_size=10, target_fps=None):
         """
         vid_source: list[string] of anything that can go in VideoCapture() including video paths and RTSP URLs
         """
@@ -33,6 +33,7 @@ class VideoLoader(DataLoader):
         self.frame_buffer = Queue(maxsize=buffer_size)
         self.thread = None
         self.stop_thread = False
+        self.target_fps = target_fps
 
     def clips_len(self):
         return self.num_clips
@@ -58,6 +59,8 @@ class VideoLoader(DataLoader):
             raise VideoCaptureError(f"Error: Could not open video stream {self.cur_clip}.")
 
         self.vid_fps = self.cap.get(cv2.CAP_PROP_FPS)
+        if self.target_fps < self.vid_fps:
+            self.cap.set(cv2.CAP_PROP_FPS, self.target_fps)
         self.total_frames = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
 
         # Start a new thread to read frames

--- a/training/pysalmcount/pysalmcount/videoloader.py
+++ b/training/pysalmcount/pysalmcount/videoloader.py
@@ -34,7 +34,7 @@ class VideoLoader(DataLoader):
         self.frame_buffer = Queue(maxsize=buffer_size)
         self.thread = None
         self.stop_thread = False
-        self.target_fps = int(target_fps)
+        self.target_fps = int(target_fps) if target_fps is not None else target_fps
 
     def clips_len(self):
         return self.num_clips
@@ -77,15 +77,16 @@ class VideoLoader(DataLoader):
 
         prev_time = 0
         while not self.stop_thread:
-            if self.target_fps < self.vid_fps:
+            if self.target_fps is not None and self.target_fps < self.vid_fps:
                 time_elapsed = time.time() - prev_time
 
             ret, frame = self.cap.read()
             if ret:
-                if self.target_fps < self.vid_fps and time_elapsed < 1. / self.target_fps:
-                    continue
-                else:
-                    prev_time = time.time()
+                if self.target_fps is not None:
+                    if self.target_fps < self.vid_fps and time_elapsed < 1. / self.target_fps:
+                        continue
+                    else:
+                        prev_time = time.time()
                 self.frame_buffer.put(frame, block=True)
             else:
                 logger.info('No more frames or failed to retrieve frame, stopping frame reading.')

--- a/training/pysalmcount/pysalmcount/videoloader.py
+++ b/training/pysalmcount/pysalmcount/videoloader.py
@@ -18,7 +18,7 @@ class VideoCaptureError(Exception):
     pass
 
 class VideoLoader(DataLoader):
-    def __init__(self, vid_sources, custom_classes=None, gstreamer_on=False, buffer_size=10, target_fps=None):
+    def __init__(self, vid_sources, custom_classes=None, gstreamer_on=False, buffer_size=10, target_fps: int=None):
         """
         vid_source: list[string] of anything that can go in VideoCapture() including video paths and RTSP URLs
         """
@@ -33,7 +33,7 @@ class VideoLoader(DataLoader):
         self.frame_buffer = Queue(maxsize=buffer_size)
         self.thread = None
         self.stop_thread = False
-        self.target_fps = target_fps
+        self.target_fps = int(target_fps)
 
     def clips_len(self):
         return self.num_clips

--- a/training/pysalmcount/pysalmcount/videoloader.py
+++ b/training/pysalmcount/pysalmcount/videoloader.py
@@ -78,14 +78,14 @@ class VideoLoader(DataLoader):
         prev_time = 0
         while not self.stop_thread:
             if self.target_fps < self.vid_fps:
-                time_elapsed = time.time() - prev
+                time_elapsed = time.time() - prev_time
 
             ret, frame = self.cap.read()
             if ret:
                 if self.target_fps < self.vid_fps and time_elapsed < 1. / self.target_fps:
                     continue
                 else:
-                    prev = time.time()
+                    prev_time = time.time()
                 self.frame_buffer.put(frame, block=True)
             else:
                 logger.info('No more frames or failed to retrieve frame, stopping frame reading.')

--- a/training/tools/run_motion_detect_rtsp.py
+++ b/training/tools/run_motion_detect_rtsp.py
@@ -51,7 +51,7 @@ def main(args):
         input_str = args.rtsp_url
 
     logger.info(input_str)
-    vidloader = vl.VideoLoader([input_str], gstreamer_on=args.gstreamer, buffer_size=2*int(args.fps))
+    vidloader = vl.VideoLoader([input_str], gstreamer_on=args.gstreamer, buffer_size=2*int(args.fps), target_fps=args.fps)
 
     logger.info(f"save_prefix: {save_prefix}")
     det = md.MotionDetector(vidloader, site_save_path, save_prefix)

--- a/training/tools/run_motion_detect_rtsp.py
+++ b/training/tools/run_motion_detect_rtsp.py
@@ -51,7 +51,7 @@ def main(args):
         input_str = args.rtsp_url
 
     logger.info(input_str)
-    vidloader = vl.VideoLoader([input_str], gstreamer_on=args.gstreamer, buffer_size=2*int(args.fps), target_fps=args.fps)
+    vidloader = vl.VideoLoader([input_str], gstreamer_on=args.gstreamer, buffer_size=2*int(args.fps), target_fps=int(args.fps))
 
     logger.info(f"save_prefix: {save_prefix}")
     det = md.MotionDetector(vidloader, site_save_path, save_prefix)


### PR DESCRIPTION
This will automatically skip frames if the source FPS is larger than the target FPS to prevent corruptioin issues from happening if the motion detection processing is slower than the source FPS.