### PR TITLE
Change the Motion Detection Code to use Multiprocessing

### DIFF
--- a/training/pysalmcount/pysalmcount/motion_detect_stream.py
+++ b/training/pysalmcount/pysalmcount/motion_detect_stream.py
@@ -215,7 +215,7 @@ class MotionDetector:
         frame_shape = (FRAME_RESIZE[1], FRAME_RESIZE[0], 3)
 
         # Create shared memory between multi processes
-        shm = shared_memory.SharedMemory(create=True, size=buffer_length * frame_shape)
+        shm = shared_memory.SharedMemory(create=True, size=buffer_length * np.prod(frame_shape))
         shared_frames = np.ndarray(
             (buffer_length, *(frame_shape)), 
             dtype=np.uint8, 

--- a/training/pysalmcount/pysalmcount/motion_detect_stream.py
+++ b/training/pysalmcount/pysalmcount/motion_detect_stream.py
@@ -207,16 +207,17 @@ class MotionDetector:
         motion_detected = False
 
         # Sacrifice first frame to get frame shape data
-        item = next(self.dataloader.items())
-        frame = item.frame
-        if isinstance(frame, str):
-            frame = cv2.imread(frame)
-        frame = cv2.resize(frame, FRAME_RESIZE, interpolation=cv2.INTER_AREA)
+        #item = next(self.dataloader.items())
+        #frame = item.frame
+        #if isinstance(frame, str):
+        #    frame = cv2.imread(frame)
+        #frame = cv2.resize(frame, FRAME_RESIZE, interpolation=cv2.INTER_AREA)
+        frame_shape = (FRAME_RESIZE[1], FRAME_RESIZE[0], 3)
 
         # Create shared memory between multi processes
-        shm = shared_memory.SharedMemory(create=True, size=buffer_length * np.prod(frame.shape))
+        shm = shared_memory.SharedMemory(create=True, size=buffer_length * frame_shape)
         shared_frames = np.ndarray(
-            (buffer_length, *(frame.shape)), 
+            (buffer_length, *(frame_shape)), 
             dtype=np.uint8, 
             buffer=shm.buf,
         )

--- a/training/pysalmcount/pysalmcount/motion_detect_stream.py
+++ b/training/pysalmcount/pysalmcount/motion_detect_stream.py
@@ -8,7 +8,8 @@ import argparse
 import datetime
 import os
 import errno
-from threading import Thread, Event, Lock, Condition
+#from threading import Thread, Event, Lock, Condition
+from multiprocessing import shared_memory, Process, Event, Lock, Condition
 import logging
 import time
 from pathlib import Path
@@ -29,10 +30,10 @@ gst_raspi_writer_str = "appsrc ! video/x-raw,format=BGR ! queue ! videoconvert !
 MOTION_VIDS_METADATA_DIR = 'motion_vids_metadata'
 VIDEO_ENCODER = 'avc1'
 
-class VideoSaver(Thread):
+class VideoSaver(Process):
     def __init__(self, buffer, folder, stop_event, lock, condition, fps=10.0, resolution=(640, 480), 
             orin=False, raspi=False, save_prefix=None):
-        Thread.__init__(self)
+        super().__init__()
         self.buffer = buffer  # This will be a shared queue
         self.folder = folder
         self.stop_event = stop_event  # This will signal when to stop recording

--- a/training/pysalmcount/pysalmcount/motion_detect_stream.py
+++ b/training/pysalmcount/pysalmcount/motion_detect_stream.py
@@ -171,6 +171,8 @@ class MotionDetector:
         MAX_CLIP = 2 * 60 # Maximum number of seconds per clip
         MAX_CONTINUOUS = 30 * 60 # Max continuous video in seconds
 
+        FRAME_RESIZE = (1280, 720)
+
         cont_dir = os.path.join(self.save_folder, 'cont_vids')
         if not os.path.exists(cont_dir):
             os.mkdir(cont_dir) # Let exception be raised if recursive dir
@@ -207,6 +209,9 @@ class MotionDetector:
         # Sacrifice first frame to get frame shape data
         item = next(self.dataloader.items())
         frame = item.frame
+        if isinstance(frame, str):
+            frame = cv2.imread(frame)
+        frame = cv2.resize(frame, FRAME_RESIZE, interpolation=cv2.INTER_AREA)
 
         # Create shared memory between multi processes
         shm = shared_memory.SharedMemory(create=True, size=buffer_length * np.prod(frame.shape))
@@ -244,7 +249,7 @@ class MotionDetector:
             frame = item.frame
             if isinstance(frame, str):
                 frame = cv2.imread(frame)
-            frame = cv2.resize(frame, (1280, 720), interpolation=cv2.INTER_AREA)
+            frame = cv2.resize(frame, FRAME_RESIZE, interpolation=cv2.INTER_AREA)
 
             if save_video:
                 if frame_counter >= MAX_CONTINUOUS_FRAMES:

--- a/training/pysalmcount/pysalmcount/videoloader.py
+++ b/training/pysalmcount/pysalmcount/videoloader.py
@@ -107,6 +107,8 @@ class VideoLoader(DataLoader):
 
             yield Item(frame, num_items=self.total_frames)
 
+        logger.info('Grabbing items stopped...')
+
     def fps(self):
         return self.vid_fps
 

--- a/utils/pi/services/Dockerfiles/Dockerfile-salmonmd-64-dev
+++ b/utils/pi/services/Dockerfiles/Dockerfile-salmonmd-64-dev
@@ -4,8 +4,7 @@ RUN apt-get update && apt-get install -y git ffmpeg python3-opencv
 
 RUN python3 -m pip install -U pip && python3 -m pip install -U ffmpeg-python
 
-ARG BRANCH=master
-RUN git clone --branch ${BRANCH} --depth 1 https://github.com/Salmon-Computer-Vision/salmon-computer-vision.git /tools
+ADD ./ /tools
 
 RUN python3 -m pip install -e /tools/training/pysalmcount
 

--- a/utils/pi/services/README.md
+++ b/utils/pi/services/README.md
@@ -34,16 +34,16 @@ HOST_GID=1000
 ORGID=<orgid>
 SITE_NAME=<site_name>
 BUCKET=<bucket>
-RTSP_URL_0=rtsp://<rtsp-url-0>
-RTSP_URL_1=rtsp://<rtsp-url-1>
+RTSP_URL=rtsp://<rtsp-url>
 FPS=10
 FLAGS=--orin --algo CNT
-DEVICE_ID_0=--device-id jetson-0
-DEVICE_ID_1=--device-id jetson-1
+DEVICE_ID=--device-id jetson-0
 ```
 
 Raspberry Pi 5 does not have a hardware encoder, so use the `--orin` flag to
 use CPU encoding.
+
+Change the `RTSP_URL` and `DEVICE_ID` to the respective URLs and Jetson ending ID hostnames.
 
 
 Older raspi do have the v4l2 or omx encoders, so set the vars like this

--- a/utils/pi/services/docker-compose.yml
+++ b/utils/pi/services/docker-compose.yml
@@ -39,13 +39,13 @@ services:
     entrypoint: /bin/sh
     command: |
       /app/syncing-counts.sh -s "${SITE_NAME}" -b "${BUCKET}" -o "${ORGID}" -d "${DRIVE}" -c /config/rclone/rclone.conf
-  salmonmd-jetson-0:
+  salmonmd-jetson:
     image: ${IMAGE_REPO_HOST}/salmonmd:${TAG}
     environment:
       - HOSTNAME
     env_file:
       - ./.env
-    container_name: salmonmd-jetson-0
+    container_name: salmonmd-jetson
     network_mode: host
     privileged: true
     user: ${HOST_UID}:${HOST_GID}
@@ -56,21 +56,4 @@ services:
       - /etc/group:/etc/group:ro
     restart: always
     command: >
-      bash -c "python3 training/tools/run_motion_detect_rtsp.py ${FLAGS} ${DEVICE_ID_0} --fps ${FPS} '${RTSP_URL_0}' \"${DRIVE}\""
-  salmonmd-jetson-1:
-    image: ${IMAGE_REPO_HOST}/salmonmd:${TAG}
-    environment:
-      - HOSTNAME
-    env_file:
-      - ./.env
-    container_name: salmonmd-jetson-1
-    network_mode: host
-    privileged: true
-    user: ${HOST_UID}:${HOST_GID}
-    volumes:
-      - ${DRIVE}:${DRIVE}
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
-    restart: always
-    command: >
-      bash -c "python3 training/tools/run_motion_detect_rtsp.py ${FLAGS} ${DEVICE_ID_1} --fps ${FPS} '${RTSP_URL_1}' \"${DRIVE}\""
+      bash -c "python3 training/tools/run_motion_detect_rtsp.py ${FLAGS} ${DEVICE_ID} --fps ${FPS} '${RTSP_URL}' \"${DRIVE}\""


### PR DESCRIPTION
The motion detection and frame grabbing slows down drastically when a video is being saved, causing skipped frames when saving video clips. This seems to be due to using `threading` as its not perfectly run in parallel due to how Python works. This converts that to use the `multiprocessing` package to properly put them in parallel and not slow down the frame grabbing.