### PR TITLE
Mount Samba using Docker Compose instead of shared mount

### DIFF
--- a/utils/jetson/salmoncount/README.md
+++ b/utils/jetson/salmoncount/README.md
@@ -139,10 +139,10 @@ to. Then, you can go to your other devices and pull the image and any changes.
 On the production devices, run the following to update:
 
 ```bash
-docker pull <image_repo_host>/salmoncounter:latest-jetson-jetpack4
+docker compose pull
 ```
 
-Spinning the services up again should automatically update the container:
+Spinning the services up again should automatically recreate the containers:
 
 ```bash
 docker compose up -d

--- a/utils/jetson/salmoncount/README.md
+++ b/utils/jetson/salmoncount/README.md
@@ -44,7 +44,8 @@ Create an `.env` file in the `salmoncount` with the following:
 ```bash
 IMAGE_REPO_HOST=<image_repo_host>
 TAG=latest-jetson-jetpack4
-DRIVE=/media
+DRIVE=network-drive
+NETWORK_DRIVE_SHARE=//192.168.1.5/HDD
 USERNAME=<device-username>
 WEIGHTS=/app/config/<salmoncount_weights>.engine
 
@@ -58,8 +59,8 @@ WEIGHTS=/app/config/<salmoncount_weights>.engine
 #FLAGS=--drop-bbox
 ```
 
-!! Make sure your drive folder is named `hdd` and is the next subdir after your `${DRIVE}` dir.
-You must have the folder format in `${DRIVE}/hdd`.
+!! Change 192.168.1.5 to the proper static IP of the device that is mounting the
+harddrive. If the Jetson is mounting the external harddrive change `DRIVE` to `DRIVE=/media/hdd`
 
 The folders in `WEIGHTS` describe within the docker container, so simply
 make sure the `<salmoncount_weights>.engine` name is the same in the config

--- a/utils/jetson/salmoncount/docker-compose.yml
+++ b/utils/jetson/salmoncount/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     env_file:
       - ./.env
     volumes:
-      - ${DRIVE}:/app/drive:shared
+      - ${DRIVE}:/app/drive/hdd
       - /home/${USERNAME}/config:/app/config
     network_mode: host
     runtime: nvidia
@@ -17,3 +17,9 @@ services:
     working_dir: /app
     command: bash -c 'export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libstdc++.so.6; python3 watcher.py ${TEST} --weights ${WEIGHTS} ${FLAGS}'
 
+volumes:
+  network-drive:
+    driver_opts:
+      type: cifs
+      o: rw,sec=none,uid=1000,gid=1000,file_mode=0777,dir_mode=0777
+      device: ${NETWORK_DRIVE_SHARE}


### PR DESCRIPTION
It seems like autofs might be causing unnecessary CPU usage, slowdown, and possible freezing of the Jetsons, so placing the mountinig within docker compose would not require autofs anymore.