### PR TITLE
Move logs to internal storage and move them externally

### DIFF
--- a/training/pysalmcount/pysalmcount/motion_detect_stream.py
+++ b/training/pysalmcount/pysalmcount/motion_detect_stream.py
@@ -399,6 +399,7 @@ class MotionDetector:
                 self.frame_log[cur_clip.name].append((frame_start, frame_counter))
                 self.stop_video_saving()
 
+            logger.info("Joining video saver process in case it has not exited")
             video_saver.join()
         except Exception as e:
             logger.error(e)

--- a/training/tools/run_motion_detect_rtsp.py
+++ b/training/tools/run_motion_detect_rtsp.py
@@ -20,7 +20,7 @@ rootlogger.addHandler(console_handler)
 
 logger = logging.getLogger(__name__)
 
-LOGS_DIR_PATH = "logs/salmonmd_logs"
+LOGS_DIR_PATH = "/tools/logs/salmonmd_logs"
 
 def read_rtsp_url(file_path):
     """Read RTSP URL from the specified file."""
@@ -48,7 +48,7 @@ def main(args):
 
     site_save_path.mkdir(exist_ok=True, parents=True)
 
-    logs_dir = site_save_path / LOGS_DIR_PATH
+    logs_dir = Path(LOGS_DIR_PATH)
     logs_dir.mkdir(exist_ok=True, parents=True)
 
     timestamp = datetime.datetime.now().strftime("%Y%m%d")

--- a/utils/pi/services/docker-compose.yml
+++ b/utils/pi/services/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     container_name: salmonmd-jetson
     network_mode: host
     privileged: true
-    user: ${HOST_UID}:${HOST_GID}
     volumes:
       - ${DRIVE}:${DRIVE}
       - /logs:/tools/logs

--- a/utils/pi/services/docker-compose.yml
+++ b/utils/pi/services/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     user: ${HOST_UID}:${HOST_GID}
     volumes:
       - ${DRIVE}:${DRIVE}
+      - /logs:/tools/logs
       - /home/${USERNAME}/2024_test_vids:/app/2024_test_vids
       - /etc/passwd:/etc/passwd:ro
       - /etc/group:/etc/group:ro


### PR DESCRIPTION
The logging code has errored out on one of our Raspi devices possibly due to faulty harddrive, preventing the videos from being recorded while not exiting the program either. This should move the logging to an internal folder, allowing a crontab to later move the logs to the external storage.