### PR TITLE
Add multi-camera feature

### DIFF
--- a/training/pysalmcount/pysalmcount/motion_detect_stream.py
+++ b/training/pysalmcount/pysalmcount/motion_detect_stream.py
@@ -9,16 +9,20 @@ import argparse
 import datetime
 import os
 import errno
+import secrets
+import threading
 #from threading import Thread, Event, Lock, Condition
 import queue
 from multiprocessing import shared_memory, Process, Event, Lock, Condition, Value, Array, Queue
 import logging
 import time
+from enum import Enum
 from pathlib import Path
 import json
-from dataclasses import asdict
 import traceback
+from dataclasses import asdict, dataclass
 import re
+from typing import Dict, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +35,263 @@ VIDEO_ENCODER = 'avc1'
 ERROR_CODE = 1
 SUCCESS_CODE = 0
 
+# Clip timing. Single source of truth: changing these values updates BOTH the
+# single-camera state machine (MotionDetector.run) AND the multi-camera
+# coordinator (MotionEventCoordinator defaults).
+MAX_CLIP_SECONDS = 120.0  # Hard cap on a single motion clip.
+PRE_ROLL_SECONDS = 2.0    # Ring-buffer depth (also the pre-roll of every clip).
+# WARNING (pre-existing): raising PRE_ROLL_SECONDS above 2.0 triggers the
+# shared-memory allocation issue the original inline comment warned about.
+# A runtime check in MotionDetector.run enforces <= 2.0 until root-caused.
+POST_ROLL_SECONDS = 5.0   # Seconds of no motion before a clip closes.
+
+
+class TickAction(Enum):
+    CONTINUE = 1   # no clip-state change
+    ROLLOVER = 2   # stop current clip (final=False); on next iter, spawn next part
+    FINALIZE = 3   # stop current clip (final=True); leave event
+
+
+@dataclass(frozen=True)
+class ClipInfo:
+    """Per-clip information minted by MotionEventCoordinator and passed into
+    VideoSaver. All clips of one logical motion episode share event_id and
+    event_start_ts; part_number distinguishes rolled segments within a cam."""
+    event_id: str
+    event_start_ts: datetime.datetime
+    part_number: int
+    originator: str
+
+
+class MotionEventCoordinator:
+    """Shared timing + fan-out across N cameras (N >= 2).
+
+    Drives lock-step clip boundaries so every cam produces the same number of
+    clips with the same wall-clock length (to within one frame period).
+
+    Lifecycle:
+      idle -> enter_event(any cam) -> open (event_id/event_start_ts minted,
+      fan-out flags set for other cams) -> other cams join via take_trigger +
+      enter_event -> MAX_CLIP rollovers broadcast via _rollover_pending ->
+      final stop broadcast via _finalize_pending once last_motion_wall is
+      stale for POST_ROLL_SECONDS -> every cam calls leave_event -> idle.
+    """
+
+    def __init__(self, cam_names: List[str],
+                 max_clip_seconds: float = MAX_CLIP_SECONDS,
+                 post_roll_seconds: float = POST_ROLL_SECONDS):
+        if len(cam_names) < 2:
+            raise ValueError(
+                "MotionEventCoordinator requires N >= 2 cameras, got "
+                f"{len(cam_names)}"
+            )
+        if len(set(cam_names)) != len(cam_names):
+            raise ValueError(
+                f"Duplicate cam_names not allowed: {cam_names}"
+            )
+        self._lock = threading.Lock()
+        self._cam_names: List[str] = list(cam_names)
+        # Fan-out "start recording now" flags set at event open. Consumed by
+        # other cams in take_trigger().
+        self._triggers: Dict[str, threading.Event] = {
+            n: threading.Event() for n in cam_names
+        }
+        # Per-cam rollover/finalize pending bits broadcast by tick().
+        self._rollover_pending: Dict[str, bool] = {n: False for n in cam_names}
+        self._finalize_pending: Dict[str, bool] = {n: False for n in cam_names}
+        # Active-event state.
+        self._active_event_id: Optional[str] = None
+        self._active_event_start: Optional[datetime.datetime] = None
+        self._event_originator: Optional[str] = None
+        self._current_part_number: int = 0
+        # time.monotonic() timestamps for drift-free shared timing.
+        self._current_part_start_wall: Optional[float] = None
+        self._last_motion_wall: Optional[float] = None
+        self._cams_recording: Set[str] = set()
+        self._max_clip_seconds = float(max_clip_seconds)
+        self._post_roll_seconds = float(post_roll_seconds)
+
+    @staticmethod
+    def _mint_event_id(now_utc: datetime.datetime) -> str:
+        return f"{now_utc.strftime('%Y%m%dT%H%M%SZ')}_{secrets.token_hex(3)}"
+
+    @staticmethod
+    def event_id_short(event_id: str) -> str:
+        """Return the short (6-hex) suffix used in filenames."""
+        # Format is 'YYYYMMDDTHHMMSSZ_abcdef'; after the underscore is the hex.
+        return event_id.rsplit('_', 1)[-1]
+
+    def enter_event(self, cam_name: str) -> ClipInfo:
+        """Atomic mint-or-join.
+
+        - Idle: mint (event_id, event_start_ts), record originator=cam,
+          set part_number=1, set current_part_start_wall and last_motion_wall
+          to now, set fan-out flags for every OTHER cam.
+        - Active: return current clip info unchanged.
+
+        In both cases: add cam_name to _cams_recording and clear this cam's
+        own fan-out flag (defense against the race where A mints and B opens
+        locally in the same instant -- B's fan-out flag would otherwise
+        linger as stale state until event close).
+        """
+        if cam_name not in self._triggers:
+            raise ValueError(f"Unknown cam_name: {cam_name!r}")
+        with self._lock:
+            if self._active_event_id is None:
+                # Mint.
+                now_wall = time.monotonic()
+                now_utc = datetime.datetime.utcnow()
+                assert cam_name not in self._cams_recording, (
+                    f"enter_event mint called but {cam_name} is already "
+                    f"recording (coordinator state corrupted?)"
+                )
+                self._active_event_id = self._mint_event_id(now_utc)
+                self._active_event_start = now_utc
+                self._event_originator = cam_name
+                self._current_part_number = 1
+                self._current_part_start_wall = now_wall
+                self._last_motion_wall = now_wall
+                # Fan out to every other cam. Clear this cam's own flag below.
+                for other in self._cam_names:
+                    if other != cam_name:
+                        self._triggers[other].set()
+            # Always join (mint branch also joins as originator).
+            self._cams_recording.add(cam_name)
+            self._triggers[cam_name].clear()
+            return ClipInfo(
+                event_id=self._active_event_id,
+                event_start_ts=self._active_event_start,
+                part_number=self._current_part_number,
+                originator=self._event_originator,
+            )
+
+    def get_current_clip_info(self) -> ClipInfo:
+        """Read-only snapshot of current clip info. Used by the rollover-
+        restart path (iter N+1 after a ROLLOVER) and any diagnostic path.
+        Raises RuntimeError if no event is active."""
+        with self._lock:
+            if self._active_event_id is None:
+                raise RuntimeError(
+                    "get_current_clip_info called while coordinator is idle"
+                )
+            return ClipInfo(
+                event_id=self._active_event_id,
+                event_start_ts=self._active_event_start,
+                part_number=self._current_part_number,
+                originator=self._event_originator,
+            )
+
+    def take_trigger(self, cam_name: str) -> bool:
+        """Atomic consume of fan-out flag. Called once per frame by each cam
+        while motion_detected=False. Returns True exactly once per set."""
+        ev = self._triggers.get(cam_name)
+        if ev is None:
+            return False
+        # threading.Event's is_set + clear is not atomic on its own, but
+        # setting is idempotent and we're the sole consumer for this cam, so
+        # acquiring the coordinator lock around it keeps enter_event and
+        # take_trigger race-free against each other.
+        with self._lock:
+            if ev.is_set():
+                ev.clear()
+                return True
+            return False
+
+    def tick(self, cam_name: str, has_motion: bool) -> TickAction:
+        """Called once per frame by each cam while motion_detected=True.
+
+        Finalize wins over rollover when both conditions would fire in the
+        same tick (avoids a trailing near-empty next-part clip).
+        """
+        with self._lock:
+            # 1. Pending signals from earlier ticks win first. Finalize is
+            # checked before rollover to match overall precedence.
+            if self._finalize_pending.get(cam_name):
+                self._finalize_pending[cam_name] = False
+                return TickAction.FINALIZE
+            if self._rollover_pending.get(cam_name):
+                self._rollover_pending[cam_name] = False
+                return TickAction.ROLLOVER
+
+            if self._active_event_id is None:
+                # No active event; nothing to do (shouldn't normally happen
+                # because caller should only tick while motion_detected=True).
+                return TickAction.CONTINUE
+
+            now_wall = time.monotonic()
+            if has_motion:
+                self._last_motion_wall = now_wall
+
+            # 2. Finalize condition: no cam has reported motion for
+            # post_roll_seconds.
+            if (self._last_motion_wall is not None and
+                    now_wall - self._last_motion_wall >= self._post_roll_seconds):
+                for n in self._cam_names:
+                    self._finalize_pending[n] = True
+                    # Finalize wins over any stale rollover that hasn't been
+                    # consumed yet (prevents trailing empty next-part clips).
+                    self._rollover_pending[n] = False
+                # Consume this cam's bit immediately.
+                self._finalize_pending[cam_name] = False
+                return TickAction.FINALIZE
+
+            # 3. Rollover condition: this clip has run for max_clip_seconds.
+            if (self._current_part_start_wall is not None and
+                    now_wall - self._current_part_start_wall >= self._max_clip_seconds):
+                self._current_part_number += 1
+                self._current_part_start_wall = now_wall
+                for n in self._cam_names:
+                    self._rollover_pending[n] = True
+                # Consume this cam's bit immediately.
+                self._rollover_pending[cam_name] = False
+                return TickAction.ROLLOVER
+
+            return TickAction.CONTINUE
+
+    def consume_finalize_if_pending(self, cam_name: str) -> bool:
+        """Check-and-clear this cam's finalize-pending bit.
+
+        Used by MotionDetector at the top of the rollover-restart path: if
+        finalize was broadcast in the gap between the rollover iter and the
+        restart iter, we want to short-circuit to FINALIZE and skip spawning
+        a next-part VideoSaver that would immediately be killed.
+        """
+        with self._lock:
+            if self._finalize_pending.get(cam_name):
+                self._finalize_pending[cam_name] = False
+                return True
+            return False
+
+    def leave_event(self, cam_name: str) -> None:
+        """Idempotent. Remove cam from _cams_recording. When the set is
+        empty, close the event: clear event_id/start/originator/part, clear
+        all _triggers/_rollover_pending/_finalize_pending flags."""
+        with self._lock:
+            self._cams_recording.discard(cam_name)
+            if not self._cams_recording and self._active_event_id is not None:
+                self._active_event_id = None
+                self._active_event_start = None
+                self._event_originator = None
+                self._current_part_number = 0
+                self._current_part_start_wall = None
+                self._last_motion_wall = None
+                for n in self._cam_names:
+                    self._triggers[n].clear()
+                    self._rollover_pending[n] = False
+                    self._finalize_pending[n] = False
+
+    def is_event_active(self) -> bool:
+        with self._lock:
+            return self._active_event_id is not None
+
 class VideoSaver(Process):
     def __init__(self, shm_name, frame_shape, head: Value, tail: Value, buffer_length, folder, stop_event, lock_head, lock_tail, condition, status_q: Queue, fps=10.0,
-            orin=False, raspi=False, save_prefix=None, is_video=False, filename=None, frame_count=0):
+            orin=False, raspi=False, save_prefix=None, is_video=False, filename=None, frame_count=0,
+            event_id: Optional[str] = None,
+            event_start_ts: Optional[datetime.datetime] = None,
+            part_number: Optional[int] = None,
+            cam_name: Optional[str] = None,
+            triggered_by: Optional[str] = None):
         super().__init__()
         self.frame_shape = frame_shape
         self.head = head
@@ -54,6 +312,12 @@ class VideoSaver(Process):
         self.is_video = is_video
         self.filename = filename
         self.frame_count = frame_count
+        # Multi-camera event fields. All None in single-cam mode.
+        self.event_id = event_id
+        self.event_start_ts = event_start_ts
+        self.part_number = part_number
+        self.cam_name = cam_name
+        self.triggered_by = triggered_by
 
         if is_video and filename is None:
             logger.warn("Filename is empty. Will fallback on timestampped name")
@@ -66,6 +330,19 @@ class VideoSaver(Process):
         )
 
     def _get_md_filename(self, suffix='_M', save_prefix=None):
+        # Multi-camera: use shared event timestamp + event hash + part number
+        # so every clip of one episode groups together and per-cam rolled
+        # segments stay ordered. `save_prefix` already carries the cam name.
+        if self.event_id is not None and self.event_start_ts is not None:
+            ts = self.event_start_ts.strftime("%Y%m%d_%H%M%S")
+            short = MotionEventCoordinator.event_id_short(self.event_id)
+            part = self.part_number if self.part_number is not None else 1
+            prefix = save_prefix if save_prefix is not None else os.uname()[1]
+            filename = self.folder / (
+                f"{prefix}_{ts}_E{short}_p{part:03d}{suffix}.mp4"
+            )
+            return str(filename)
+
         if not self.is_video or self.filename is None:
             filename = VideoSaver.get_output_filename(self.folder, save_prefix=self.save_prefix)
         else:
@@ -165,23 +442,57 @@ class VideoSaver(Process):
             self.condition.notify_all() # Signal to Producer to stop blocking
 
         metadata = utils.get_video_metadata(filename)
-        if metadata is not None:
-            logger.info(f"Metadata for video file {filename}: {metadata}")
+        if metadata is None:
+            logger.error(f"Could not generate metadata for file: {filename}")
+
+        # Build the metadata JSON payload.
+        # - Single-cam (event_id is None): preserve today's behavior, only
+        #   write the file when ffmpeg metadata probe succeeded.
+        # - Multi-cam (event_id set): always write the file, even if the
+        #   probe failed, so downstream grouping by event_id always works.
+        payload = asdict(metadata) if metadata is not None else {}
+        if self.event_id is not None:
+            payload.update({
+                "event_id": self.event_id,
+                "event_start_ts": (
+                    self.event_start_ts.isoformat()
+                    if self.event_start_ts is not None else None
+                ),
+                "cam_name": self.cam_name,
+                "triggered_by": self.triggered_by,
+                "part_number": self.part_number,
+            })
+
+        if payload:
             metadata_filepath = VideoSaver.filename_to_metadata_filepath(Path(filename))
             logger.info(f"Saving metadata file to harddrive: {str(metadata_filepath)}")
             with open(str(metadata_filepath), 'w') as f:
-                json.dump(asdict(metadata), f)
+                json.dump(payload, f)
         else:
             tb = traceback.format_exc()
             logger.error(f"Could not generate metadata for file: {filename}")
             logger.error(tb)
             self.status_q.put((ERROR_CODE, ("", tb)))
 
+class _CamLoggerAdapter(logging.LoggerAdapter):
+    """Prefix every log record with [cam_name] regardless of the root
+    formatter, so a combined multi-cam log file stays readable."""
+
+    def __init__(self, base_logger: logging.Logger, cam_name: str):
+        super().__init__(base_logger, {"cam_name": cam_name})
+        self._cam_name = cam_name
+
+    def process(self, msg, kwargs):
+        return f"[{self._cam_name}] {msg}", kwargs
+
+
 class MotionDetector:
     FILENAME = 'filename'
     CLIPS = 'clips'
 
-    def __init__(self, dataloader: DataLoader, save_folder, save_video=True, save_cont_video=True, is_video=False, save_prefix=None, ping_url='https://google.com'):
+    def __init__(self, dataloader: DataLoader, save_folder, save_video=True, save_cont_video=True, is_video=False, save_prefix=None, ping_url='https://google.com',
+                 coordinator: Optional[MotionEventCoordinator] = None,
+                 cam_name: Optional[str] = None):
         self.dataloader = dataloader
         self.save_folder = save_folder
         self.frame_log = {}
@@ -193,6 +504,18 @@ class MotionDetector:
         self.save_cont_video = save_cont_video
         self.motion_counter = 0
         self.motion_detected = False
+
+        # Multi-camera coordination. coordinator is None => single-cam mode
+        # with exact legacy behavior.
+        self.coordinator = coordinator
+        self.cam_name = cam_name
+        self._awaiting_next_part: bool = False
+        # Per-cam log adapter so every record is tagged with [cam_name] in
+        # multi-cam mode. In single-cam mode fall back to the module logger.
+        if cam_name is not None:
+            self.log = _CamLoggerAdapter(logger, cam_name)
+        else:
+            self.log = logger
 
         # Concurrency-safe constructs
         self.stop_event = Event()
@@ -215,10 +538,22 @@ class MotionDetector:
                 return True
         return False
 
-    def stop_video_saving(self):
+    def stop_video_saving(self, final: bool = True):
+        """Stop the currently-recording VideoSaver.
+
+        final=True  -> post-roll or end-of-stream; in multi-cam mode also
+                       calls coordinator.leave_event so the cam drops out of
+                       _cams_recording (possibly closing the event).
+        final=False -> MAX_CLIP rollover; the cam will start its next part
+                       on the next loop iteration via the _awaiting_next_part
+                       path; coordinator participation is preserved.
+        """
         self.motion_counter = 0
         if self.save_video and not self.stop_event.is_set():
-            logger.info("Stopping recording.")
+            if final:
+                self.log.info("Stopping recording.")
+            else:
+                self.log.info("Rolling to next clip part.")
             self.stop_event.set()
             with self.condition:
                 self.condition.notify_all()  # Signal the VideoSaver thread to stop waiting and finish
@@ -226,6 +561,49 @@ class MotionDetector:
         elif not self.save_video:
             self.motion_detected = False
 
+        if final and self.coordinator is not None and self.cam_name is not None:
+            try:
+                self.coordinator.leave_event(self.cam_name)
+            except Exception:
+                # leave_event is idempotent and must never raise; log and swallow
+                # to keep shutdown paths robust.
+                self.log.exception("coordinator.leave_event raised")
+
+
+    def _spawn_video_saver(self, motion_dir, raw, frame_shape, head, tail,
+                           buffer_length, fps, orin, raspi, cur_clip_name,
+                           frame_counter, clip_info: Optional[ClipInfo]):
+        """Construct and start a new VideoSaver for this cam's next clip.
+
+        Shared by all three multi-cam entry points (fan-out, local-open,
+        rollover-restart) as well as the single-cam open path. When
+        ``clip_info`` is None we're in single-cam mode and VideoSaver falls
+        back to today's timestamp-based filename.
+        """
+        self.stop_event.clear()
+        vs_kwargs = {}
+        if clip_info is not None:
+            vs_kwargs.update(
+                event_id=clip_info.event_id,
+                event_start_ts=clip_info.event_start_ts,
+                part_number=clip_info.part_number,
+                cam_name=self.cam_name,
+                triggered_by=clip_info.originator,
+            )
+        video_saver = VideoSaver(
+            shm_name=raw, frame_shape=frame_shape, head=head, tail=tail,
+            buffer_length=buffer_length, folder=motion_dir,
+            stop_event=self.stop_event, lock_head=self.lock_head,
+            lock_tail=self.lock_tail, condition=self.condition,
+            status_q=self.status_q, fps=fps,
+            orin=orin, raspi=raspi, save_prefix=self.save_prefix,
+            is_video=self.is_video, filename=cur_clip_name,
+            frame_count=frame_counter, **vs_kwargs,
+        )
+        video_saver.start()
+        self.motion_detected = True
+        self.motion_counter = 0
+        return video_saver
 
     def run(self, algo='MOG2', fps: int=None, orin=False, raspi=False, staging=False):
         # Motion Detection Params
@@ -239,24 +617,32 @@ class MotionDetector:
         min_contour_area = 10000 # Ignore contour objects smaller than this area
         MOTION_EVENTS_THRESH = 0.4 # Ratio of seconds of motion required to trigger detection
 
-        # WARNING: Cannot be larger than 2 or else the program will simply exit when allocating more frames
-        BUFFER_LENGTH = 2 # Number of seconds before motion to keep
-
-        MAX_CLIP = 2 * 60 # Maximum number of seconds per clip
-        MAX_CONTINUOUS = 30 * 60 # Max continuous video in seconds
+        # Clip-timing values come from the module-level single source of truth.
+        # Change MAX_CLIP_SECONDS / PRE_ROLL_SECONDS / POST_ROLL_SECONDS at the
+        # top of this file and both single-cam and multi-cam pick up the new
+        # values (the coordinator defaults read from the same constants).
+        if PRE_ROLL_SECONDS > 2.0:
+            raise ValueError(
+                f"PRE_ROLL_SECONDS={PRE_ROLL_SECONDS} > 2.0 is known to crash "
+                "the shared-memory allocation on this code path; see TODO at "
+                "the top of motion_detect_stream.py."
+            )
+        BUFFER_LENGTH = PRE_ROLL_SECONDS  # seconds
+        MAX_CLIP = MAX_CLIP_SECONDS       # seconds
+        MAX_CONTINUOUS = 30 * 60          # seconds; unrelated to motion clips
 
         FRAME_RESIZE = (1280, 720)
 
+        # Race-safe directory creation for multi-cam threads sharing one
+        # device_id folder. os.mkdir's no-exist check was not thread-safe.
         cont_dir = os.path.join(self.save_folder, 'cont_vids')
-        if not os.path.exists(cont_dir):
-            os.mkdir(cont_dir) # Let exception be raised if recursive dir
+        Path(cont_dir).mkdir(parents=True, exist_ok=True)
 
         if staging:
             motion_dir = os.path.join(self.save_folder, MOTION_VIDS_STAGING)
         else:
             motion_dir = os.path.join(self.save_folder, MOTION_VIDS)
-        if not os.path.exists(motion_dir):
-            os.mkdir(motion_dir) # Let exception be raised if recursive dir
+        Path(motion_dir).mkdir(parents=True, exist_ok=True)
 
         cur_clip = self.dataloader.next_clip()
         self.frame_log[cur_clip.name] = []
@@ -268,7 +654,7 @@ class MotionDetector:
             if fps > self.dataloader.fps():
                 fps = self.dataloader.fps()
 
-        logger.info(f"FPS: {fps}")
+        self.log.info(f"FPS: {fps}")
 
         MAX_FRAMES_CLIP = int(MAX_CLIP * fps)
         MAX_CONTINUOUS_FRAMES = int(MAX_CONTINUOUS * fps)
@@ -284,6 +670,7 @@ class MotionDetector:
         warm_up = fps
         buffer_length = int(fps * BUFFER_LENGTH)  # Buffer to save before motion
         self.motion_detected = False
+        self._awaiting_next_part = False
 
         # Sacrifice first frame to get frame shape data
         #item = next(self.dataloader.items())
@@ -302,13 +689,13 @@ class MotionDetector:
             dtype=dtype, 
             buffer=raw,
         )
-        logger.info(f"Size of shared frames: {shared_frames.shape}")
+        self.log.info(f"Size of shared frames: {shared_frames.shape}")
 
         # Create pointers for circular array
         head = Value('i', 0)
         tail = Value('i', 0)
 
-        delay = int(fps * 5) # Number of seconds to delay after motion
+        delay = int(fps * POST_ROLL_SECONDS) # Number of frames of no-motion before stopping (single-cam only)
         count_delay = 0
 
         video_saver = None
@@ -317,168 +704,285 @@ class MotionDetector:
         self.motion_counter = 0
         num_motion_events = 0
         frame_start = 0
-        for item in self.dataloader.items():
-            if utils.is_check_time(frame_counter, fps):
-                start_time=time.time()
 
-            frame = np.ascontiguousarray(item.frame)
-            if isinstance(frame, str):
-                frame = cv2.imread(frame)
-            frame = cv2.resize(frame, FRAME_RESIZE, interpolation=cv2.INTER_AREA)
+        multicam = self.coordinator is not None and self.cam_name is not None
 
-            if self.save_cont_video:
-                if frame_counter >= MAX_CONTINUOUS_FRAMES:
-                    cont_filename = VideoSaver.get_output_filename(cont_dir, '_C', save_prefix=self.save_prefix)
-                    logger.info(f"Writing continuous video to {cont_filename}")
-                    if orin:
-                        cont_vid_out = cv2.VideoWriter(cont_filename, cv2.VideoWriter_fourcc(*VIDEO_ENCODER),
-                                fps, (frame.shape[1], frame.shape[0]))
-                    else:
-                        gst_writer = gst_writer_str
-                        if raspi:
-                            logger.info("Writing with raspi hardware...")
-                            gst_writer = gst_raspi_writer_str
-                        cont_vid_out = cv2.VideoWriter(gst_writer + cont_filename, 
-                                                       cv2.CAP_GSTREAMER, 0, fps, (frame.shape[1], frame.shape[0]))
-                        logger.info(f"Created VideoWriter to {cont_filename}")
-                    frame_counter = 0
+        try:
+            for item in self.dataloader.items():
+                if utils.is_check_time(frame_counter, fps):
+                    start_time=time.time()
+
+                frame = np.ascontiguousarray(item.frame)
+                if isinstance(frame, str):
+                    frame = cv2.imread(frame)
+                frame = cv2.resize(frame, FRAME_RESIZE, interpolation=cv2.INTER_AREA)
+
+                if self.save_cont_video:
+                    if frame_counter >= MAX_CONTINUOUS_FRAMES:
+                        cont_filename = VideoSaver.get_output_filename(cont_dir, '_C', save_prefix=self.save_prefix)
+                        self.log.info(f"Writing continuous video to {cont_filename}")
+                        if orin:
+                            cont_vid_out = cv2.VideoWriter(cont_filename, cv2.VideoWriter_fourcc(*VIDEO_ENCODER),
+                                    fps, (frame.shape[1], frame.shape[0]))
+                        else:
+                            gst_writer = gst_writer_str
+                            if raspi:
+                                self.log.info("Writing with raspi hardware...")
+                                gst_writer = gst_raspi_writer_str
+                            cont_vid_out = cv2.VideoWriter(gst_writer + cont_filename,
+                                                           cv2.CAP_GSTREAMER, 0, fps, (frame.shape[1], frame.shape[0]))
+                            self.log.info(f"Created VideoWriter to {cont_filename}")
+                        frame_counter = 0
+
+                    if utils.is_check_time(frame_counter, fps):
+                        start_in_time = time.time()
+
+                    cont_vid_out.write(frame)
+
+                    if utils.is_check_time(frame_counter, fps):
+                        end_in_time=time.time()
+                        elapsed_in_time = (end_in_time - start_in_time) * 1000
+                        self.log.info(f"Cont save: {elapsed_in_time:.2f} ms")
 
                 if utils.is_check_time(frame_counter, fps):
                     start_in_time = time.time()
 
-                cont_vid_out.write(frame)
+                # Apply background subtraction algorithm to get the foreground mask
+                fg_mask = bgsub.apply(frame)
 
                 if utils.is_check_time(frame_counter, fps):
                     end_in_time=time.time()
                     elapsed_in_time = (end_in_time - start_in_time) * 1000
-                    logger.info(f"Cont save: {elapsed_in_time:.2f} ms")
+                    self.log.info(f"BGSub: {elapsed_in_time:.2f} ms")
+                #cont_vid_out.write(cv2.cvtColor(fg_mask, cv2.COLOR_GRAY2RGB))
 
-            if utils.is_check_time(frame_counter, fps):
-                start_in_time = time.time()
+                if utils.is_check_time(frame_counter, fps):
+                    start_in_time = time.time()
+                has_motion = False
+                if warm_up <= 0:
+                    # Apply a threshold to the foreground mask to get rid of noise
+                    _, fg_mask = cv2.threshold(fg_mask, threshold_value, 255, cv2.THRESH_BINARY)
 
-            # Apply background subtraction algorithm to get the foreground mask
-            fg_mask = bgsub.apply(frame)
+                    # Apply morphological operations to clean up the mask
+                    fg_mask = cv2.erode(fg_mask, None, iterations=erode_iter)
+                    fg_mask = cv2.dilate(fg_mask, None, iterations=dilate_iter)
 
-            if utils.is_check_time(frame_counter, fps):
-                end_in_time=time.time()
-                elapsed_in_time = (end_in_time - start_in_time) * 1000
-                logger.info(f"BGSub: {elapsed_in_time:.2f} ms")
-            #cont_vid_out.write(cv2.cvtColor(fg_mask, cv2.COLOR_GRAY2RGB))
-
-            if utils.is_check_time(frame_counter, fps):
-                start_in_time = time.time()
-            has_motion = False
-            if warm_up <= 0:
-                # Apply a threshold to the foreground mask to get rid of noise
-                _, fg_mask = cv2.threshold(fg_mask, threshold_value, 255, cv2.THRESH_BINARY)
-
-                # Apply morphological operations to clean up the mask
-                fg_mask = cv2.erode(fg_mask, None, iterations=erode_iter) 
-                fg_mask = cv2.dilate(fg_mask, None, iterations=dilate_iter) 
-
-                # Now detect motion
-                has_motion = self.detect_motion(fg_mask, min_area=min_contour_area)
-            else:
-                warm_up -= 1
-            if utils.is_check_time(frame_counter, fps):
-                end_in_time=time.time()
-                elapsed_in_time = (end_in_time - start_in_time) * 1000
-                logger.info(f"check motion: {elapsed_in_time:.2f} ms")
-
-            with self.lock_head:
-                frame_idx = head.value % buffer_length
-                logger.debug(f"Frame index: {frame_idx}, Head: {head.value}, Buffer length: {buffer_length}")
-
-                with self.lock_tail:
-                    buf_full = (head.value + 1) % buffer_length == tail.value
-
-            # Check if head is overtaking tail (buffer full)
-            if buf_full and self.motion_detected:
-                # Wait until saver consumes a frame
-                with self.condition:
-                    self.condition.wait_for(
-                        lambda: (head.value + 1) % buffer_length != tail.value or self.stop_event.is_set()
-                    )
-            elif buf_full:
-                logger.debug("Buffer full! Overwriting old frames.")
-                with self.lock_tail:
-                    # Advance the tail to the next frame to make space
-                    tail.value = (tail.value + 1) % buffer_length
-
-            with self.lock_head:
-                shared_frames[frame_idx] = frame
-                head.value = (head.value + 1) % buffer_length
-
-            with self.condition:
-                self.condition.notify() # Signal the VideoSaver thread that a new frame is available
-
-            if self.motion_detected:
-                self.motion_counter += 1
-
-            # TESTING ONLY
-            #if self.motion_counter >= 100:
-            #    has_motion = not has_motion
-
-            # Check for motion
-            if has_motion:
-                num_motion_events += 1
-                count_delay = 0
-                if video_saver is None or (not video_saver.is_alive() and 
-                        not self.motion_detected and num_motion_events >= MOTION_EVENTS_THRESH_FRAMES):
-                    logger.info(f"Motion detected with {num_motion_events} events")
-                    self.motion_detected = True
-                    self.motion_counter = 0
-                    frame_start = frame_counter
-                    if self.save_video:
-                        # Signal that we need to start saving the clip
-                        self.stop_event.clear()
-                        video_saver = VideoSaver(
-                                shm_name=raw, frame_shape=frame.shape, head=head, tail=tail, 
-                                buffer_length=buffer_length, folder=motion_dir, 
-                                stop_event=self.stop_event, lock_head=self.lock_head, lock_tail=self.lock_tail, condition=self.condition, status_q=self.status_q, fps=fps, 
-                                orin=orin, raspi=raspi, save_prefix=self.save_prefix, is_video=self.is_video, filename=cur_clip.name, frame_count=frame_counter)
-                        video_saver.start()
-                elif self.motion_counter > MAX_FRAMES_CLIP:
-                    logger.info("Max clip length exceeded")
-                    self.stop_video_saving()
-            else:
-                num_motion_events = 0
-                if count_delay < delay:
-                    count_delay += 1
+                    # Now detect motion
+                    has_motion = self.detect_motion(fg_mask, min_area=min_contour_area)
                 else:
-                    # If motion has stopped and we have a video saver running, set the stop event
-                    if self.motion_detected:
-                        logger.info("Delay exceeded. Motion stopped.")
-                        self.frame_log[cur_clip.name].append((frame_start, frame_counter))
-                        self.stop_video_saving()
+                    warm_up -= 1
+                if utils.is_check_time(frame_counter, fps):
+                    end_in_time=time.time()
+                    elapsed_in_time = (end_in_time - start_in_time) * 1000
+                    self.log.info(f"check motion: {elapsed_in_time:.2f} ms")
 
+                with self.lock_head:
+                    frame_idx = head.value % buffer_length
+                    self.log.debug(f"Frame index: {frame_idx}, Head: {head.value}, Buffer length: {buffer_length}")
 
-            try: 
-                status, _ = self.status_q.get_nowait()
-                if status == ERROR_CODE:
-                    break # Exit if something happens during saving
-            except queue.Empty:
-                pass
+                    with self.lock_tail:
+                        buf_full = (head.value + 1) % buffer_length == tail.value
 
-            if utils.is_check_time(frame_counter, fps):
-                end_time=time.time()
-                elapsed_time = (end_time - start_time) * 1000
-                logger.info(f"Time elapsed: {elapsed_time:.2f} ms")
-                utils.ping_in_background(self.ping_url)
-            frame_counter += 1
+                # Check if head is overtaking tail (buffer full)
+                if buf_full and self.motion_detected:
+                    # Wait until saver consumes a frame
+                    with self.condition:
+                        self.condition.wait_for(
+                            lambda: (head.value + 1) % buffer_length != tail.value or self.stop_event.is_set()
+                        )
+                elif buf_full:
+                    self.log.debug("Buffer full! Overwriting old frames.")
+                    with self.lock_tail:
+                        # Advance the tail to the next frame to make space
+                        tail.value = (tail.value + 1) % buffer_length
 
-        try:
-            self.dataloader.close()
+                with self.lock_head:
+                    shared_frames[frame_idx] = frame
+                    head.value = (head.value + 1) % buffer_length
+
+                with self.condition:
+                    self.condition.notify() # Signal the VideoSaver thread that a new frame is available
+
+                if self.motion_detected:
+                    self.motion_counter += 1
+
+                # ----- State machine -----
+                if multicam:
+                    # --- Multi-cam path ---
+                    if self._awaiting_next_part:
+                        # Previous iteration returned ROLLOVER; spawn the next
+                        # part's VideoSaver on THIS iteration. First short-
+                        # circuit to FINALIZE if the finalize condition fired
+                        # in the gap -- prevents a 1-2 frame trailing clip.
+                        if self.coordinator.consume_finalize_if_pending(self.cam_name):
+                            self._awaiting_next_part = False
+                            # Nothing to stop (old saver already closed via
+                            # rollover); just leave the event and reset state.
+                            self.frame_log[cur_clip.name].append((frame_start, frame_counter))
+                            if self.coordinator is not None:
+                                try:
+                                    self.coordinator.leave_event(self.cam_name)
+                                except Exception:
+                                    self.log.exception("coordinator.leave_event raised")
+                            self.motion_detected = False
+                            num_motion_events = 0
+                            count_delay = 0
+                        else:
+                            info = self.coordinator.get_current_clip_info()
+                            self.log.info(
+                                f"Rolling into part {info.part_number} of event {info.event_id}"
+                            )
+                            if self.save_video:
+                                video_saver = self._spawn_video_saver(
+                                    motion_dir, raw, frame.shape, head, tail,
+                                    buffer_length, fps, orin, raspi,
+                                    cur_clip.name, frame_counter, info,
+                                )
+                            else:
+                                self.motion_detected = True
+                                self.motion_counter = 0
+                            self._awaiting_next_part = False
+                    elif self.motion_detected:
+                        action = self.coordinator.tick(self.cam_name, has_motion)
+                        if action is TickAction.ROLLOVER:
+                            self.log.info("Max clip length reached; rollover")
+                            self.stop_video_saving(final=False)
+                            self._awaiting_next_part = True
+                        elif action is TickAction.FINALIZE:
+                            self.log.info("Post-roll exceeded; finalizing clip")
+                            self.frame_log[cur_clip.name].append((frame_start, frame_counter))
+                            self.stop_video_saving(final=True)
+                            # Reset noise-filter state so the next event
+                            # still requires 0.4 s of sustained motion.
+                            num_motion_events = 0
+                            count_delay = 0
+                        # action CONTINUE: nothing extra; frame already in buf
+                    else:
+                        # Idle in multi-cam mode.
+                        if self.coordinator.take_trigger(self.cam_name):
+                            # Fan-out: another cam opened an event.
+                            info = self.coordinator.enter_event(self.cam_name)
+                            self.log.info(
+                                f"Fan-out trigger; joining event {info.event_id} "
+                                f"(originator={info.originator}) as part "
+                                f"{info.part_number}"
+                            )
+                            frame_start = frame_counter
+                            if self.save_video:
+                                video_saver = self._spawn_video_saver(
+                                    motion_dir, raw, frame.shape, head, tail,
+                                    buffer_length, fps, orin, raspi,
+                                    cur_clip.name, frame_counter, info,
+                                )
+                            else:
+                                self.motion_detected = True
+                                self.motion_counter = 0
+                            num_motion_events = 0
+                            count_delay = 0
+                        else:
+                            # Local-motion detection path (threshold-gated).
+                            # Only the bookkeeping matters while idle -- we
+                            # don't need the inner stop branches (can't fire
+                            # because motion_detected is False here).
+                            if has_motion:
+                                num_motion_events += 1
+                                count_delay = 0
+                                if num_motion_events >= MOTION_EVENTS_THRESH_FRAMES:
+                                    info = self.coordinator.enter_event(self.cam_name)
+                                    self.log.info(
+                                        f"Local motion crossed threshold; "
+                                        f"entering event {info.event_id} "
+                                        f"(originator={info.originator})"
+                                    )
+                                    frame_start = frame_counter
+                                    if self.save_video:
+                                        video_saver = self._spawn_video_saver(
+                                            motion_dir, raw, frame.shape,
+                                            head, tail, buffer_length, fps,
+                                            orin, raspi, cur_clip.name,
+                                            frame_counter, info,
+                                        )
+                                    else:
+                                        self.motion_detected = True
+                                        self.motion_counter = 0
+                            else:
+                                num_motion_events = 0
+                                if count_delay < delay:
+                                    count_delay += 1
+                else:
+                    # --- Single-cam path: preserved verbatim from today ---
+                    if has_motion:
+                        num_motion_events += 1
+                        count_delay = 0
+                        if not self.motion_detected and num_motion_events >= MOTION_EVENTS_THRESH_FRAMES:
+                            self.log.info(f"Motion detected with {num_motion_events} events")
+                            self.motion_detected = True
+                            self.motion_counter = 0
+                            frame_start = frame_counter
+                            if self.save_video:
+                                video_saver = self._spawn_video_saver(
+                                    motion_dir, raw, frame.shape, head, tail,
+                                    buffer_length, fps, orin, raspi,
+                                    cur_clip.name, frame_counter, None,
+                                )
+                        elif self.motion_counter > MAX_FRAMES_CLIP:
+                            self.log.info("Max clip length exceeded")
+                            self.stop_video_saving(final=True)
+                    else:
+                        num_motion_events = 0
+                        if count_delay < delay:
+                            count_delay += 1
+                        else:
+                            # If motion has stopped and we have a video saver running, set the stop event
+                            if self.motion_detected:
+                                self.log.info("Delay exceeded. Motion stopped.")
+                                self.frame_log[cur_clip.name].append((frame_start, frame_counter))
+                                self.stop_video_saving(final=True)
+
+                try:
+                    status, _ = self.status_q.get_nowait()
+                    if status == ERROR_CODE:
+                        break # Exit if something happens during saving
+                except queue.Empty:
+                    pass
+
+                if utils.is_check_time(frame_counter, fps):
+                    end_time=time.time()
+                    elapsed_time = (end_time - start_time) * 1000
+                    self.log.info(f"Time elapsed: {elapsed_time:.2f} ms")
+                    utils.ping_in_background(self.ping_url)
+                frame_counter += 1
+        finally:
+            try:
+                self.dataloader.close()
+            except Exception:
+                self.log.exception("dataloader.close raised")
 
             if self.motion_detected:
-                logger.info("No more frames. Motion stopped.")
-                self.frame_log[cur_clip.name].append((frame_start, frame_counter))
-                self.stop_video_saving()
+                self.log.info("No more frames. Motion stopped.")
+                try:
+                    self.frame_log[cur_clip.name].append((frame_start, frame_counter))
+                except Exception:
+                    self.log.exception("frame_log append failed")
+                try:
+                    self.stop_video_saving(final=True)
+                except Exception:
+                    self.log.exception("stop_video_saving raised")
 
-            logger.info("Joining video saver process in case it has not exited")
+            # In multi-cam mode, ensure the coordinator always lets this cam
+            # leave so a dying cam cannot keep _cams_recording populated.
+            # leave_event is idempotent; safe to call even if stop_video_saving
+            # already did.
+            if multicam and self.coordinator is not None:
+                try:
+                    self.coordinator.leave_event(self.cam_name)
+                except Exception:
+                    self.log.exception("coordinator.leave_event raised")
+
+            self.log.info("Joining video saver process in case it has not exited")
             if video_saver and video_saver.is_alive():
-                video_saver.join()
-        except Exception as e:
-            logger.error(e)
-            raise
+                try:
+                    video_saver.join()
+                except Exception:
+                    self.log.exception("video_saver.join raised")
         return self.frame_log

--- a/training/tools/run_motion_detect_rtsp.py
+++ b/training/tools/run_motion_detect_rtsp.py
@@ -4,12 +4,15 @@ from pysalmcount import motion_detect_stream as md
 
 import argparse
 import os
+import re
 import sys
 import logging
+import threading
 from logging.handlers import TimedRotatingFileHandler
 import datetime
 from pathlib import Path
 import time
+from typing import List, Optional, Tuple
 
 # Set up logging
 log_format = '%(asctime)s - %(levelname)s [%(filename)s:%(lineno)d] - %(message)s'
@@ -105,6 +108,77 @@ def get_orgid_and_site_name(name):
     return orgid, site_name, device_id
 
 
+CAM_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _build_input_str(url: str, gstreamer: bool, h265: bool) -> str:
+    """Wrap a raw RTSP URL in the appropriate pipeline when gstreamer is on.
+
+    Extracted so both the single-cam and multi-cam paths build their
+    per-URL pipeline the same way.
+    """
+    if gstreamer:
+        if h265:
+            return (
+                f"rtspsrc location={url} ! decodebin ! queue ! v4l2convert "
+                "! video/x-raw,format=BGR ! appsink drop=1"
+            )
+        return (
+            f"rtspsrc location={url} ! rtph264depay ! h264parse "
+            "! v4l2h264dec ! videoconvert ! appsink"
+        )
+    return url
+
+
+def _parse_multi_camera_args(args) -> Tuple[List[str], List[str]]:
+    """Parse and validate the multi-camera CLI inputs.
+
+    Returns (urls, cam_names). Raises SystemExit (via argparse-style ValueError)
+    on invalid input.
+    """
+    urls = [u.strip() for u in args.input.split(',') if u.strip()]
+    if len(urls) < 2:
+        raise ValueError(
+            "--multi-camera requires at least 2 comma-separated RTSP URLs "
+            f"in the input argument; got {len(urls)}: {args.input!r}"
+        )
+
+    if args.cam_names:
+        cam_names = [c.strip() for c in args.cam_names.split(',')]
+        if any(not c for c in cam_names):
+            raise ValueError(
+                f"--cam-names contains empty entries: {args.cam_names!r}"
+            )
+    else:
+        cam_names = [f"cam{i+1}" for i in range(len(urls))]
+
+    if len(cam_names) != len(urls):
+        raise ValueError(
+            f"Number of --cam-names ({len(cam_names)}) does not match "
+            f"number of RTSP URLs ({len(urls)})"
+        )
+
+    for name in cam_names:
+        if not CAM_NAME_RE.match(name):
+            raise ValueError(
+                f"cam name {name!r} is invalid: must match [A-Za-z0-9_-]+"
+            )
+
+    if len(set(cam_names)) != len(cam_names):
+        raise ValueError(f"cam names must be unique; got {cam_names}")
+
+    return urls, cam_names
+
+
+def _run_detector_in_thread(det, fps, algo, orin, raspi, staging, cam_name):
+    """Thread target that logs any crash in the cam's detector without
+    bringing down the other cams' threads."""
+    try:
+        det.run(fps=fps, algo=algo, orin=orin, raspi=raspi, staging=staging)
+    except Exception:
+        logger.exception("[%s] detector thread crashed", cam_name)
+
+
 def main(args):
     save_cont_video = not args.no_cont if args.no_cont is not None else True
     is_video = args.video if args.video is not None else False
@@ -128,22 +202,69 @@ def main(args):
 
     logger.info(f"Writing logs to {log_file}")
 
-    if args.gstreamer:
-        #input_str = f"rtspsrc location={args.input} ! rtph265depay ! h265parse ! avdec_h265 ! v4l2convert ! video/x-raw,format=BGR ! appsink drop=1"
-        if args.h265:
-            input_str = f"rtspsrc location={args.input} ! decodebin ! queue ! v4l2convert ! video/x-raw,format=BGR ! appsink drop=1"
-        else:
-            #input_str = f"rtspsrc location={args.input} ! rtph264depay ! queue ! h264parse ! v4l2h264dec ! queue ! v4l2convert ! video/x-raw,format=BGR ! appsink drop=1"
-            input_str = f"rtspsrc location={args.input} ! rtph264depay ! h264parse ! v4l2h264dec ! videoconvert ! appsink"
-    else:
-        input_str = args.input
+    fps = int(args.fps)
 
+    if args.multi_camera:
+        urls, cam_names = _parse_multi_camera_args(args)
+        logger.info(
+            "Multi-camera mode: %d cameras, names=%s", len(urls), cam_names
+        )
+
+        # Share ONE coordinator across all cam threads. Timing defaults come
+        # from the module-level constants in motion_detect_stream.py; changing
+        # those constants automatically applies to both single- and multi-cam.
+        coordinator = md.MotionEventCoordinator(cam_names)
+
+        detectors = []
+        for url, cam_name in zip(urls, cam_names):
+            input_str = _build_input_str(url, args.gstreamer, args.h265)
+            logger.info("[%s] input: %s", cam_name, input_str)
+            vidloader = vl.VideoLoader(
+                [input_str],
+                gstreamer_on=args.gstreamer,
+                buffer_size=2 * fps,
+                target_fps=fps,
+            )
+            cam_save_prefix = (
+                f"{save_prefix}_{cam_name}" if save_prefix is not None else cam_name
+            )
+            det = md.MotionDetector(
+                dataloader=vidloader,
+                save_folder=site_save_path,
+                save_prefix=cam_save_prefix,
+                ping_url=args.url,
+                save_cont_video=save_cont_video,
+                is_video=is_video,
+                coordinator=coordinator,
+                cam_name=cam_name,
+            )
+            detectors.append((det, cam_name))
+
+        threads = []
+        for det, cam_name in detectors:
+            t = threading.Thread(
+                target=_run_detector_in_thread,
+                args=(det, fps, args.algo, args.orin, args.raspi,
+                      args.staging, cam_name),
+                name=f"MotionDetector-{cam_name}",
+                daemon=False,
+            )
+            t.start()
+            threads.append(t)
+
+        for t in threads:
+            t.join()
+        logger.info("All multi-camera detector threads have exited.")
+        return
+
+    # --- Single-camera path (today's behavior) ---
+    input_str = _build_input_str(args.input, args.gstreamer, args.h265)
     logger.info(input_str)
-    vidloader = vl.VideoLoader([input_str], gstreamer_on=args.gstreamer, buffer_size=2*int(args.fps), target_fps=int(args.fps))
+    vidloader = vl.VideoLoader([input_str], gstreamer_on=args.gstreamer, buffer_size=2*fps, target_fps=fps)
 
     logger.info(f"save_prefix: {save_prefix}")
     det = md.MotionDetector(dataloader=vidloader, save_folder=site_save_path, save_prefix=save_prefix, ping_url=args.url, save_cont_video=save_cont_video, is_video=is_video)
-    det.run(fps=int(args.fps), algo=args.algo, orin=args.orin, raspi=args.raspi, staging=args.staging)
+    det.run(fps=fps, algo=args.algo, orin=args.orin, raspi=args.raspi, staging=args.staging)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Salmon Motion Detection and Video Clip Saving")
@@ -162,6 +283,24 @@ if __name__ == "__main__":
     parser.add_argument("--no-cont", action='store_true', help="Set this flag to not save continuous video")
     parser.add_argument("--staging", action='store_true', help="Set this flag to save to a staging folder for edge salmon counting processing")
     parser.add_argument(
+        "--multi-camera", action='store_true', dest='multi_camera',
+        help=(
+            "Enable multi-camera mode. The positional input is then treated "
+            "as a comma-separated list of RTSP URLs (N >= 2). All cameras "
+            "share lock-step clip boundaries (same event_id, same "
+            "part_number count, same wall-clock length) via a coordinator."
+        ),
+    )
+    parser.add_argument(
+        "--cam-names", default=None, dest='cam_names',
+        help=(
+            "Comma-separated camera names used to disambiguate clips in "
+            "multi-camera mode. Each name must match [A-Za-z0-9_-]+, no "
+            "duplicates. Length must equal the number of RTSP URLs in the "
+            "positional input. Defaults to cam1,cam2,...,camN."
+        ),
+    )
+    parser.add_argument(
         '-d', '--debug',
         help="Print lots of debugging statements",
         action="store_const", dest="loglevel", const=logging.DEBUG,
@@ -169,6 +308,12 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+
+    if args.multi_camera:
+        try:
+            _parse_multi_camera_args(args)
+        except ValueError as exc:
+            parser.error(str(exc))
 
     install_excepthook()
 

--- a/utils/jetson/salmonmd/template.env
+++ b/utils/jetson/salmonmd/template.env
@@ -35,3 +35,11 @@ DEVICE_ID=jetson-0
 # --help to see all the options
 # Add `--staging` flag if salmon counting processing will be done on an edge device
 FLAGS=--orin --url 'https://google.com'
+
+# --- Multi-camera mode (optional) ---------------------------------------
+# Set RTSP_URL to a comma-separated list of >= 2 RTSP URLs and add the
+# `--multi-camera` flag (plus `--cam-names`) to FLAGS to run N cameras in
+# one container.
+# Example:
+#   RTSP_URL=rtsp://192.168.1.88/0,rtsp://192.168.1.89/0,rtsp://192.168.1.90/0
+#   FLAGS=--orin --multi-camera --cam-names cam1,cam2,cam3 --url 'https://google.com'


### PR DESCRIPTION
This pull request adds support for running motion detection on multiple RTSP camera streams in a single process, with synchronized event boundaries and improved configuration. It introduces a new multi-camera mode, argument parsing, and threading to handle each camera independently, while maintaining backward compatibility with single-camera usage.

**Multi-camera support:**

* Added `--multi-camera` and `--cam-names` command-line arguments to enable and configure multi-camera mode, allowing users to specify multiple RTSP URLs and unique camera names.
* Implemented `_parse_multi_camera_args` to validate and parse multi-camera inputs, ensuring correct number of URLs and names, uniqueness, and allowed characters.
* Updated the `main` function to launch a `MotionDetector` thread for each camera, all coordinated by a shared `MotionEventCoordinator`, and to log and handle thread crashes gracefully.

**Code structure and maintainability:**

* Refactored RTSP pipeline construction into `_build_input_str` for consistent handling across single- and multi-camera modes.

**Documentation and configuration:**

* Updated `template.env` with instructions and examples for configuring and running multi-camera mode using the new arguments.