### PR TITLE
Prevent camera from rejoining finalizing events

### DIFF
--- a/training/pysalmcount/pysalmcount/motion_detect_stream.py
+++ b/training/pysalmcount/pysalmcount/motion_detect_stream.py
@@ -428,23 +428,35 @@ class VideoSaver(Process):
             short = MotionEventCoordinator.event_id_short(self.event_id)
             part = self.part_number if self.part_number is not None else 1
             prefix = save_prefix if save_prefix is not None else os.uname()[1]
-            filename = self.folder / (
-                f"{prefix}_{ts}_E{short}_p{part:03d}{suffix}.mp4"
-            )
-            # Safety net: the coordinator finalizing-guard should already
-            # prevent a returning cam from reusing an event's frozen identity,
-            # so this path is not expected to collide. If it ever does, never
-            # silently overwrite an existing clip (and its metadata JSON) --
-            # log loudly and uniquify with a short random token instead.
+            base = f"{prefix}_{ts}_E{short}_p{part:03d}"
+            filename = self.folder / f"{base}{suffix}.mp4"
+            # The coordinator finalizing-guard guarantees a returning cam mints
+            # a fresh event_id instead of reusing this event's frozen identity,
+            # so this path must never collide. If the "impossible" collision
+            # ever happens, NEVER overwrite the existing clip (that would be
+            # silent data loss). Instead preserve it and write the new clip
+            # under a collision-marked name: prefix with "collision_" and append
+            # a UTC systime tag (with microseconds) before the label suffix so
+            # the file still ends in ..._M.mp4. The tag makes the name unique;
+            # a random token is added only in the astronomically unlikely event
+            # the tag itself clashes.
+            # NOTE: collision-marked names intentionally deviate from the strict
+            # cloud filename scheme, so such clips may need manual handling
+            # downstream -- acceptable because a collision signals a real bug.
             if filename.exists():
-                token = secrets.token_hex(2)
                 collided = filename
-                filename = self.folder / (
-                    f"{prefix}_{ts}_E{short}_p{part:03d}_r{token}{suffix}.mp4"
-                )
+                now_tag = datetime.datetime.now(
+                    datetime.timezone.utc
+                ).strftime("%Y%m%dT%H%M%S%fZ")
+                filename = self.folder / f"collision_{base}_{now_tag}{suffix}.mp4"
+                while filename.exists():
+                    token = secrets.token_hex(2)
+                    filename = self.folder / f"collision_{base}_{now_tag}_{token}{suffix}.mp4"
                 logger.error(
                     "Motion clip path already exists (unexpected collision): "
-                    "%s; writing to %s instead to avoid overwrite",
+                    "%s; preserving it and writing new clip to %s instead. "
+                    "This indicates event-identity reuse -- investigate the "
+                    "coordinator finalize/leave logic.",
                     str(collided), str(filename),
                 )
             return str(filename)
@@ -752,20 +764,19 @@ class MotionDetector:
         """
         self.motion_counter = 0
 
-        def _leave_event_if_final():
-            # Drop this cam from the event BEFORE the potentially long
-            # VideoSaver.join() below. If we leave only after the join, the
-            # shared event stays "active" for the whole drain, and a cam that
-            # already finished could rejoin the closing event and reuse its
-            # frozen event_id/part_number (overwriting an existing clip).
-            # Leaving early only touches coordinator bookkeeping; the outgoing
-            # VideoSaver already carries its own ClipInfo. leave_event is
-            # idempotent, so the finally-block call is still safe.
-            if final and self.coordinator is not None and self.cam_name is not None:
-                try:
-                    self.coordinator.leave_event(self.cam_name)
-                except Exception:
-                    self.log.exception("coordinator.leave_event raised")
+        # Leave the event BEFORE the potentially long VideoSaver.join() below.
+        # If we left only after draining, the shared event would stay "active"
+        # for the whole drain window, letting a cam that already finished rejoin
+        # the closing event and reuse its frozen event_id/part_number (which
+        # would overwrite an existing clip). Leaving here only updates
+        # coordinator bookkeeping; the outgoing VideoSaver already carries its
+        # own ClipInfo, so its filename is unaffected. leave_event is
+        # idempotent, so the run()-finally safety-net call remains safe.
+        if final and self.coordinator is not None and self.cam_name is not None:
+            try:
+                self.coordinator.leave_event(self.cam_name)
+            except Exception:
+                self.log.exception("coordinator.leave_event raised")
 
         if self.save_video and self.video_saver_stop_event is not None:
             if final:
@@ -777,8 +788,6 @@ class MotionDetector:
 
             with self.condition:
                 self.condition.notify_all()
-
-            _leave_event_if_final()
 
             if self.video_saver is not None and self.video_saver.is_alive():
                 self.log.info("Joining VideoSaver pid=%s", self.video_saver.pid)
@@ -799,9 +808,6 @@ class MotionDetector:
 
         elif not self.save_video:
             self.motion_detected = False
-            _leave_event_if_final()
-        else:
-            _leave_event_if_final()
 
 
     def _spawn_video_saver(self, motion_dir, raw, frame_shape, head, tail,

--- a/training/pysalmcount/pysalmcount/motion_detect_stream.py
+++ b/training/pysalmcount/pysalmcount/motion_detect_stream.py
@@ -108,6 +108,12 @@ class MotionEventCoordinator:
         self._current_part_start_wall: Optional[float] = None
         self._last_motion_wall: Optional[float] = None
         self._cams_recording: Set[str] = set()
+        # Set True the instant a finalize is broadcast (in tick) and cleared
+        # when the event fully closes (in leave_event) or a fresh event is
+        # minted (in enter_event). While True, enter_event refuses to (re)join
+        # the closing event so a returning cam cannot reuse the old frozen
+        # event_id/event_start_ts/part_number and overwrite an existing clip.
+        self._finalizing: bool = False
         self._max_clip_seconds = float(max_clip_seconds)
         self._post_roll_seconds = float(post_roll_seconds)
 
@@ -121,17 +127,24 @@ class MotionEventCoordinator:
         # Format is 'YYYYMMDDTHHMMSSZ_abcdef'; after the underscore is the hex.
         return event_id.rsplit('_', 1)[-1]
 
-    def enter_event(self, cam_name: str) -> ClipInfo:
+    def enter_event(self, cam_name: str) -> Optional[ClipInfo]:
         """Atomic mint-or-join.
 
         - Idle: mint (event_id, event_start_ts), record originator=cam,
           set part_number=1, set current_part_start_wall and last_motion_wall
           to now, set fan-out flags for every OTHER cam.
-        - Active: return current clip info unchanged.
+        - Active (not finalizing): return current clip info unchanged.
+        - Active AND finalizing: return None. The current event is draining
+          (finalize already broadcast) so we refuse to (re)join it; the caller
+          should defer and retry next frame, at which point the event will have
+          closed and a fresh event_id gets minted. This is what prevents a cam
+          that finished + left from rejoining a still-draining event and
+          reusing the old frozen identity (which would overwrite an existing
+          clip on disk).
 
-        In both cases: add cam_name to _cams_recording and clear this cam's
-        own fan-out flag (defense against the race where A mints and B opens
-        locally in the same instant -- B's fan-out flag would otherwise
+        In the mint/join cases: add cam_name to _cams_recording and clear this
+        cam's own fan-out flag (defense against the race where A mints and B
+        opens locally in the same instant -- B's fan-out flag would otherwise
         linger as stale state until event close).
         """
         if cam_name not in self._triggers:
@@ -151,11 +164,15 @@ class MotionEventCoordinator:
                 self._current_part_number = 1
                 self._current_part_start_wall = now_wall
                 self._last_motion_wall = now_wall
+                self._finalizing = False
                 # Fan out to every other cam. Clear this cam's own flag below.
                 for other in self._cam_names:
                     if other != cam_name:
                         self._triggers[other].set()
-            # Always join (mint branch also joins as originator).
+            elif self._finalizing:
+                # Event is draining; refuse to join. Caller defers + retries.
+                return None
+            # Join (mint branch also joins as originator).
             self._cams_recording.add(cam_name)
             self._triggers[cam_name].clear()
             return ClipInfo(
@@ -226,6 +243,9 @@ class MotionEventCoordinator:
             # post_roll_seconds.
             if (self._last_motion_wall is not None and
                     now_wall - self._last_motion_wall >= self._post_roll_seconds):
+                # Mark the event as closing so enter_event refuses new joins
+                # for the rest of the drain (see enter_event finalizing branch).
+                self._finalizing = True
                 for n in self._cam_names:
                     self._finalize_pending[n] = True
                     # Finalize wins over any stale rollover that hasn't been
@@ -275,6 +295,7 @@ class MotionEventCoordinator:
                 self._current_part_number = 0
                 self._current_part_start_wall = None
                 self._last_motion_wall = None
+                self._finalizing = False
                 for n in self._cam_names:
                     self._triggers[n].clear()
                     self._rollover_pending[n] = False
@@ -410,6 +431,22 @@ class VideoSaver(Process):
             filename = self.folder / (
                 f"{prefix}_{ts}_E{short}_p{part:03d}{suffix}.mp4"
             )
+            # Safety net: the coordinator finalizing-guard should already
+            # prevent a returning cam from reusing an event's frozen identity,
+            # so this path is not expected to collide. If it ever does, never
+            # silently overwrite an existing clip (and its metadata JSON) --
+            # log loudly and uniquify with a short random token instead.
+            if filename.exists():
+                token = secrets.token_hex(2)
+                collided = filename
+                filename = self.folder / (
+                    f"{prefix}_{ts}_E{short}_p{part:03d}_r{token}{suffix}.mp4"
+                )
+                logger.error(
+                    "Motion clip path already exists (unexpected collision): "
+                    "%s; writing to %s instead to avoid overwrite",
+                    str(collided), str(filename),
+                )
             return str(filename)
 
         if not self.is_video or self.filename is None:
@@ -715,6 +752,21 @@ class MotionDetector:
         """
         self.motion_counter = 0
 
+        def _leave_event_if_final():
+            # Drop this cam from the event BEFORE the potentially long
+            # VideoSaver.join() below. If we leave only after the join, the
+            # shared event stays "active" for the whole drain, and a cam that
+            # already finished could rejoin the closing event and reuse its
+            # frozen event_id/part_number (overwriting an existing clip).
+            # Leaving early only touches coordinator bookkeeping; the outgoing
+            # VideoSaver already carries its own ClipInfo. leave_event is
+            # idempotent, so the finally-block call is still safe.
+            if final and self.coordinator is not None and self.cam_name is not None:
+                try:
+                    self.coordinator.leave_event(self.cam_name)
+                except Exception:
+                    self.log.exception("coordinator.leave_event raised")
+
         if self.save_video and self.video_saver_stop_event is not None:
             if final:
                 self.log.info("Stopping recording.")
@@ -725,6 +777,8 @@ class MotionDetector:
 
             with self.condition:
                 self.condition.notify_all()
+
+            _leave_event_if_final()
 
             if self.video_saver is not None and self.video_saver.is_alive():
                 self.log.info("Joining VideoSaver pid=%s", self.video_saver.pid)
@@ -745,12 +799,9 @@ class MotionDetector:
 
         elif not self.save_video:
             self.motion_detected = False
-
-        if final and self.coordinator is not None and self.cam_name is not None:
-            try:
-                self.coordinator.leave_event(self.cam_name)
-            except Exception:
-                self.log.exception("coordinator.leave_event raised")
+            _leave_event_if_final()
+        else:
+            _leave_event_if_final()
 
 
     def _spawn_video_saver(self, motion_dir, raw, frame_shape, head, tail,
@@ -1152,26 +1203,35 @@ class MotionDetector:
                         if self.coordinator.take_trigger(self.cam_name):
                             # Fan-out: another cam opened an event.
                             info = self.coordinator.enter_event(self.cam_name)
-                            self.log.info(
-                                f"Fan-out trigger; joining event {info.event_id} "
-                                f"(originator={info.originator}) as part "
-                                f"{info.part_number}"
-                            )
-                            frame_start = frame_counter
-                            if self.save_video:
-                                ensure_writable_dir(motion_dir, "motion video")
-                                video_saver = self._spawn_video_saver(
-                                    motion_dir, raw, frame.shape, head, tail,
-                                    buffer_length, fps, orin, raspi,
-                                    cur_clip.name, frame_counter, info,
-                                    cpu_h264, bitrate,
+                            if info is None:
+                                # Event is draining (finalizing). Defer; the
+                                # trigger was already consumed by take_trigger,
+                                # so nothing lingers. Retry on a later frame.
+                                self.log.info(
+                                    "Fan-out trigger arrived while event is "
+                                    "finalizing; deferring join"
                                 )
-                                self._raise_if_video_saver_failed()
                             else:
-                                self.motion_detected = True
-                                self.motion_counter = 0
-                            num_motion_events = 0
-                            count_delay = 0
+                                self.log.info(
+                                    f"Fan-out trigger; joining event {info.event_id} "
+                                    f"(originator={info.originator}) as part "
+                                    f"{info.part_number}"
+                                )
+                                frame_start = frame_counter
+                                if self.save_video:
+                                    ensure_writable_dir(motion_dir, "motion video")
+                                    video_saver = self._spawn_video_saver(
+                                        motion_dir, raw, frame.shape, head, tail,
+                                        buffer_length, fps, orin, raspi,
+                                        cur_clip.name, frame_counter, info,
+                                        cpu_h264, bitrate,
+                                    )
+                                    self._raise_if_video_saver_failed()
+                                else:
+                                    self.motion_detected = True
+                                    self.motion_counter = 0
+                                num_motion_events = 0
+                                count_delay = 0
                         else:
                             # Local-motion detection path (threshold-gated).
                             # Only the bookkeeping matters while idle -- we
@@ -1182,25 +1242,38 @@ class MotionDetector:
                                 count_delay = 0
                                 if num_motion_events >= MOTION_EVENTS_THRESH_FRAMES:
                                     info = self.coordinator.enter_event(self.cam_name)
-                                    self.log.info(
-                                        f"Local motion crossed threshold; "
-                                        f"entering event {info.event_id} "
-                                        f"(originator={info.originator})"
-                                    )
-                                    frame_start = frame_counter
-                                    if self.save_video:
-                                        ensure_writable_dir(motion_dir, "motion video")
-                                        video_saver = self._spawn_video_saver(
-                                            motion_dir, raw, frame.shape,
-                                            head, tail, buffer_length, fps,
-                                            orin, raspi, cur_clip.name,
-                                            frame_counter, info,
-                                            cpu_h264, bitrate,
+                                    if info is None:
+                                        # Previous event is still draining
+                                        # (finalizing). Defer minting a fresh
+                                        # event: leave num_motion_events intact
+                                        # so we retry next frame, at which point
+                                        # the old event has closed and a new
+                                        # event_id is minted (no filename reuse).
+                                        self.log.info(
+                                            "Local motion crossed threshold "
+                                            "while previous event is "
+                                            "finalizing; deferring new event"
                                         )
-                                        self._raise_if_video_saver_failed()
                                     else:
-                                        self.motion_detected = True
-                                        self.motion_counter = 0
+                                        self.log.info(
+                                            f"Local motion crossed threshold; "
+                                            f"entering event {info.event_id} "
+                                            f"(originator={info.originator})"
+                                        )
+                                        frame_start = frame_counter
+                                        if self.save_video:
+                                            ensure_writable_dir(motion_dir, "motion video")
+                                            video_saver = self._spawn_video_saver(
+                                                motion_dir, raw, frame.shape,
+                                                head, tail, buffer_length, fps,
+                                                orin, raspi, cur_clip.name,
+                                                frame_counter, info,
+                                                cpu_h264, bitrate,
+                                            )
+                                            self._raise_if_video_saver_failed()
+                                        else:
+                                            self.motion_detected = True
+                                            self.motion_counter = 0
                             else:
                                 num_motion_events = 0
                                 if count_delay < delay:

--- a/utils/jetson/salmonmd/template.env
+++ b/utils/jetson/salmonmd/template.env
@@ -38,7 +38,7 @@ FLAGS=--cpu_h264 --url 'https://google.com'
 
 # --- Multi-camera mode (optional) ---------------------------------------
 # Set RTSP_URL to a comma-separated list of >= 2 RTSP URLs and add the
-# `--multi-camera` flag (plus `--cam-names`) to FLAGS to run N cameras in
+# `--multi-camera` flag (plus optional `--cam-names`) to FLAGS to run N cameras in
 # one container.
 # Example:
 #   RTSP_URL=rtsp://192.168.1.88/0,rtsp://192.168.1.89/0,rtsp://192.168.1.90/0


### PR DESCRIPTION
This pull request introduces robust safeguards to prevent video clip overwrites during event finalization in the motion detection coordinator logic. It ensures that cameras cannot rejoin or mint events while an event is draining (finalizing), and adds an extra safety net to avoid filename collisions. The changes also improve the reliability of event state transitions and logging.

**Event finalization and coordination improvements:**

* Added a `_finalizing` flag to the coordinator to track when an event is in the process of finalizing, preventing cameras from rejoining or minting new events during this state. The `enter_event` method now returns `None` if called while finalizing, signaling the caller to defer and retry later. [[1]](diffhunk://#diff-f1c0d317e6a676ec5f39c7583a6d5aad636d7f8b03d5fa26ee1d786c866bd087R111-R116) [[2]](diffhunk://#diff-f1c0d317e6a676ec5f39c7583a6d5aad636d7f8b03d5fa26ee1d786c866bd087L124-R147) [[3]](diffhunk://#diff-f1c0d317e6a676ec5f39c7583a6d5aad636d7f8b03d5fa26ee1d786c866bd087R167-R175) [[4]](diffhunk://#diff-f1c0d317e6a676ec5f39c7583a6d5aad636d7f8b03d5fa26ee1d786c866bd087R246-R248) [[5]](diffhunk://#diff-f1c0d317e6a676ec5f39c7583a6d5aad636d7f8b03d5fa26ee1d786c866bd087R298)
* Updated the main event loop to handle `None` returns from `enter_event`, deferring join/mint attempts until the event has fully closed, thus preventing reuse of event IDs and filenames. [[1]](diffhunk://#diff-f1c0d317e6a676ec5f39c7583a6d5aad636d7f8b03d5fa26ee1d786c866bd087R1206-R1214) [[2]](diffhunk://#diff-f1c0d317e6a676ec5f39c7583a6d5aad636d7f8b03d5fa26ee1d786c866bd087R1245-R1257)

**File safety and logging:**

* Enhanced `_get_md_filename` to check for unexpected filename collisions; if a collision is detected, a random token is appended to the filename and a loud error is logged, ensuring no existing clips or metadata are overwritten.

**Event exit timing:**

* Modified `stop_video_saving` to drop the camera from the event before joining the `VideoSaver` thread, minimizing the window during which a camera could accidentally rejoin a draining event and overwrite a clip. [[1]](diffhunk://#diff-f1c0d317e6a676ec5f39c7583a6d5aad636d7f8b03d5fa26ee1d786c866bd087R755-R769) [[2]](diffhunk://#diff-f1c0d317e6a676ec5f39c7583a6d5aad636d7f8b03d5fa26ee1d786c866bd087R781-R782) [[3]](diffhunk://#diff-f1c0d317e6a676ec5f39c7583a6d5aad636d7f8b03d5fa26ee1d786c866bd087L748-R804)