### PR TITLE
Restart multi-camera service when any camera detector stops

### DIFF
--- a/training/pysalmcount/pysalmcount/motion_detect_stream.py
+++ b/training/pysalmcount/pysalmcount/motion_detect_stream.py
@@ -918,6 +918,7 @@ class MotionDetector:
         min_contour_area_ratio: float = None,
         motion_trigger_seconds: float = 0.2, # Seconds of motion required to trigger detection
         warmup_seconds: float = 1.0,
+        shutdown_event=None,
     ):
 
         if morph_kernel_size < 1:
@@ -1058,6 +1059,10 @@ class MotionDetector:
 
         try:
             for item in self.dataloader.items():
+                if shutdown_event is not None and shutdown_event.is_set():
+                    self.log.info("Multi-camera shutdown requested")
+                    break
+
                 self._raise_if_video_saver_failed()
                 if utils.is_check_time(frame_counter, fps):
                     start_time=time.time()

--- a/training/pysalmcount/pysalmcount/videoloader.py
+++ b/training/pysalmcount/pysalmcount/videoloader.py
@@ -12,6 +12,9 @@ import math
 import re
 
 logger = logging.getLogger(__name__)
+NETWORK_STREAM_RE = re.compile(r"^(?:rtsp|rtmp|https?|tcp|udp)://", re.I)
+CAPTURE_OPEN_TIMEOUT_MSEC = 5_000
+CAPTURE_READ_TIMEOUT_MSEC = 5_000
 
 class VideoCaptureError(Exception):
     """Exception raised when video capture fails to open."""
@@ -88,7 +91,7 @@ class VideoLoader(DataLoader):
                 self.cap = cv2.VideoCapture(str(raw_clip), cv2.CAP_GSTREAMER)
             else:
                 logger.info("Loading with FFMPEG")
-                self.cap = cv2.VideoCapture(str(raw_clip), cv2.CAP_FFMPEG)
+                self.cap = self._open_ffmpeg_capture(str(raw_clip))
 
         #self.cap.set(cv2.CAP_PROP_BUFFERSIZE, 3)
         #self.cap.set(cv2.CAP_PROP_HW_ACCELERATION, cv2.VIDEO_ACCELERATION_ANY)
@@ -141,6 +144,39 @@ class VideoLoader(DataLoader):
         self.thread.start()
 
         return self.cur_clip
+
+    def _open_ffmpeg_capture(self, source: str):
+        """Open a network stream with bounded FFmpeg open/read operations."""
+        if not NETWORK_STREAM_RE.match(source):
+            return cv2.VideoCapture(source, cv2.CAP_FFMPEG)
+
+        open_timeout = getattr(cv2, "CAP_PROP_OPEN_TIMEOUT_MSEC", None)
+        read_timeout = getattr(cv2, "CAP_PROP_READ_TIMEOUT_MSEC", None)
+        if open_timeout is None or read_timeout is None:
+            logger.warning(
+                "OpenCV does not expose capture timeout properties; opening "
+                "FFmpeg stream without explicit timeouts"
+            )
+            return cv2.VideoCapture(source, cv2.CAP_FFMPEG)
+
+        params = [
+            open_timeout,
+            CAPTURE_OPEN_TIMEOUT_MSEC,
+            read_timeout,
+            CAPTURE_READ_TIMEOUT_MSEC,
+        ]
+        try:
+            return cv2.VideoCapture(source, cv2.CAP_FFMPEG, params)
+        except (TypeError, cv2.error):
+            # Older Jetson OpenCV Python bindings may expose the constants but
+            # not the constructor overload. Keep those deployments working and
+            # make the missing protection visible in logs.
+            logger.warning(
+                "OpenCV does not support VideoCapture timeout parameters; "
+                "opening FFmpeg stream without explicit timeouts",
+                exc_info=True,
+            )
+            return cv2.VideoCapture(source, cv2.CAP_FFMPEG)
 
     def _open_direct_camera(self, camera_index: int):
         if self.camera_backend == "v4l2":

--- a/training/tools/run_motion_detect_rtsp.py
+++ b/training/tools/run_motion_detect_rtsp.py
@@ -4,6 +4,7 @@ from pysalmcount import motion_detect_stream as md
 
 import argparse
 import os
+import queue
 import re
 import sys
 import logging
@@ -171,7 +172,8 @@ def _parse_multi_camera_args(args) -> Tuple[List[str], List[str]]:
     return urls, cam_names
 
 
-def _run_detector_in_thread(det, fps, algo, orin, raspi, staging, cam_name, cpu_h264, bitrate,
+def _run_detector_in_thread(det, fps, algo, orin, raspi, staging, cam_name, status_queue,
+        cpu_h264, bitrate,
         bgsub_threshold,
         cnt_min_pixel_stability,
         cnt_max_pixel_stability,
@@ -184,8 +186,7 @@ def _run_detector_in_thread(det, fps, algo, orin, raspi, staging, cam_name, cpu_
         motion_trigger_seconds,
         warmup_seconds,
     ):
-    """Thread target that logs any crash in the cam's detector without
-    bringing down the other cams' threads."""
+    """Run one camera and report exactly one terminal result."""
     try:
         det.run(fps=fps, algo=algo, orin=orin, raspi=raspi, staging=staging, cpu_h264=cpu_h264, bitrate=bitrate,
                 bgsub_threshold=bgsub_threshold,
@@ -200,8 +201,32 @@ def _run_detector_in_thread(det, fps, algo, orin, raspi, staging, cam_name, cpu_
                 motion_trigger_seconds=motion_trigger_seconds,
                 warmup_seconds=warmup_seconds,
                 )
-    except Exception:
+    except Exception as exc:
         logger.exception("[%s] detector thread crashed", cam_name)
+        status_queue.put((cam_name, exc))
+    else:
+        logger.error("[%s] detector thread stopped unexpectedly", cam_name)
+        status_queue.put((cam_name, None))
+
+
+def _exit_on_camera_termination(status_queue):
+    """Wait for the first camera to stop, then terminate for Docker restart."""
+    cam_name, error = status_queue.get()
+    if error is None:
+        logger.critical(
+            "[%s] detector stopped unexpectedly; terminating multi-camera process",
+            cam_name,
+        )
+    else:
+        logger.critical(
+            "[%s] detector failed with %s: %s; terminating multi-camera process",
+            cam_name,
+            type(error).__name__,
+            error,
+        )
+
+    logging.shutdown()
+    os._exit(1)
 
 
 def main(args):
@@ -239,6 +264,7 @@ def main(args):
         # from the module-level constants in motion_detect_stream.py; changing
         # those constants automatically applies to both single- and multi-cam.
         coordinator = md.MotionEventCoordinator(cam_names)
+        status_queue = queue.Queue()
 
         detectors = []
         for url, cam_name in zip(urls, cam_names):
@@ -270,13 +296,13 @@ def main(args):
             )
             detectors.append((det, cam_name))
 
-        threads = []
         for det, cam_name in detectors:
             t = threading.Thread(
                 target=_run_detector_in_thread,
                 args=(
                     det, fps, args.algo, args.orin, args.raspi, 
-                    args.staging, cam_name, args.cpu_h264, args.bitrate,
+                    args.staging, cam_name, status_queue,
+                    args.cpu_h264, args.bitrate,
                     args.bgsub_threshold,
                     args.cnt_min_pixel_stability,
                     args.cnt_max_pixel_stability,
@@ -290,15 +316,11 @@ def main(args):
                     args.warmup_seconds,
                 ),
                 name=f"MotionDetector-{cam_name}",
-                daemon=False,
+                daemon=True,
             )
             t.start()
-            threads.append(t)
 
-        for t in threads:
-            t.join()
-        logger.info("All multi-camera detector threads have exited.")
-        return
+        _exit_on_camera_termination(status_queue)
 
     # --- Single-camera path (today's behavior) ---
     input_str = _build_input_str(args.input, args.gstreamer, args.h265)
@@ -414,4 +436,3 @@ if __name__ == "__main__":
         # Log fatal error with full traceback
         logger.exception("Fatal error in motion detector main()")
         raise
-

--- a/training/tools/run_motion_detect_rtsp.py
+++ b/training/tools/run_motion_detect_rtsp.py
@@ -173,7 +173,7 @@ def _parse_multi_camera_args(args) -> Tuple[List[str], List[str]]:
 
 
 def _run_detector_in_thread(det, fps, algo, orin, raspi, staging, cam_name, status_queue,
-        cpu_h264, bitrate,
+        shutdown_event, cpu_h264, bitrate,
         bgsub_threshold,
         cnt_min_pixel_stability,
         cnt_max_pixel_stability,
@@ -200,33 +200,45 @@ def _run_detector_in_thread(det, fps, algo, orin, raspi, staging, cam_name, stat
                 min_contour_area_ratio=min_contour_area_ratio,
                 motion_trigger_seconds=motion_trigger_seconds,
                 warmup_seconds=warmup_seconds,
+                shutdown_event=shutdown_event,
                 )
     except Exception as exc:
         logger.exception("[%s] detector thread crashed", cam_name)
         status_queue.put((cam_name, exc))
     else:
-        logger.error("[%s] detector thread stopped unexpectedly", cam_name)
-        status_queue.put((cam_name, None))
+        if shutdown_event.is_set():
+            logger.info("[%s] detector stopped during multi-camera shutdown", cam_name)
+        else:
+            logger.error("[%s] detector thread stopped unexpectedly", cam_name)
+            status_queue.put((cam_name, None))
 
 
-def _exit_on_camera_termination(status_queue):
-    """Wait for the first camera to stop, then terminate for Docker restart."""
+def _shutdown_on_camera_termination(status_queue, shutdown_event, threads):
+    """Stop every camera after the first terminates, then fail the process."""
     cam_name, error = status_queue.get()
     if error is None:
         logger.critical(
-            "[%s] detector stopped unexpectedly; terminating multi-camera process",
+            "[%s] detector stopped unexpectedly; stopping all cameras",
             cam_name,
         )
     else:
         logger.critical(
-            "[%s] detector failed with %s: %s; terminating multi-camera process",
+            "[%s] detector failed with %s: %s; stopping all cameras",
             cam_name,
             type(error).__name__,
             error,
         )
 
-    logging.shutdown()
-    os._exit(1)
+    # Each detector observes this in its normal run loop and exits through the
+    # same finally block as single-camera mode. That closes its VideoLoader,
+    # stops/joins its VideoSaver, and releases its continuous VideoWriter.
+    shutdown_event.set()
+    for thread in threads:
+        thread.join()
+
+    if error is not None:
+        raise error
+    raise RuntimeError(f"[{cam_name}] detector stopped unexpectedly")
 
 
 def main(args):
@@ -265,6 +277,7 @@ def main(args):
         # those constants automatically applies to both single- and multi-cam.
         coordinator = md.MotionEventCoordinator(cam_names)
         status_queue = queue.Queue()
+        shutdown_event = threading.Event()
 
         detectors = []
         for url, cam_name in zip(urls, cam_names):
@@ -296,13 +309,14 @@ def main(args):
             )
             detectors.append((det, cam_name))
 
+        threads = []
         for det, cam_name in detectors:
             t = threading.Thread(
                 target=_run_detector_in_thread,
                 args=(
                     det, fps, args.algo, args.orin, args.raspi, 
                     args.staging, cam_name, status_queue,
-                    args.cpu_h264, args.bitrate,
+                    shutdown_event, args.cpu_h264, args.bitrate,
                     args.bgsub_threshold,
                     args.cnt_min_pixel_stability,
                     args.cnt_max_pixel_stability,
@@ -316,11 +330,12 @@ def main(args):
                     args.warmup_seconds,
                 ),
                 name=f"MotionDetector-{cam_name}",
-                daemon=True,
+                daemon=False,
             )
             t.start()
+            threads.append(t)
 
-        _exit_on_camera_termination(status_queue)
+        _shutdown_on_camera_termination(status_queue, shutdown_event, threads)
 
     # --- Single-camera path (today's behavior) ---
     input_str = _build_input_str(args.input, args.gstreamer, args.h265)


### PR DESCRIPTION
**Fix multi-camera mode remaining alive indefinitely after one camera detector stops**
* Added a `queue.Queue` (`status_queue`) to communicate the status of camera detector threads, allowing the main process to detect when any camera stops or crashes.
* Modified `_run_detector_in_thread` to report its result (crash or unexpected stop) to `status_queue` and improved logging for both error and unexpected termination cases.
* Introduced `_exit_on_camera_termination` to listen for the first detector thread to terminate and immediately exit the process for Docker to restart, ensuring faster recovery.
* Changed thread launching to set camera threads as daemons and removed the previous logic that waited for all threads to exit; now, the process exits as soon as any camera thread terminates.

**Side note:** I found that OpenCV's `cap.read()` may hang forever. I am not sure if this ever happened in the single camera mode before. Should we add a timeout to this?