### PR TITLE
Henryf/feature mutli rgb clip compositie

### DIFF
--- a/training/pysalmcount/pysalmcount/clip_compositor.py
+++ b/training/pysalmcount/pysalmcount/clip_compositor.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Post-process synchronized per-camera motion clips into one vertical clip."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+import re
+import secrets
+import subprocess
+from dataclasses import asdict, dataclass
+from multiprocessing import Process
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from pysalmcount import utils
+
+
+logger = logging.getLogger(__name__)
+
+MOTION_VIDS_METADATA_DIR = "motion_vids_metadata"
+MOTION_VIDS_PARTS_METADATA = "motion_vids_parts_metadata"
+
+PART_TAIL_RE = re.compile(
+    r"_(?P<date>\d{8})_(?P<time>\d{6})_E(?P<event>[0-9a-f]{6})_"
+    r"p(?P<part>\d{3})_M\.mp4$"
+)
+
+
+@dataclass(frozen=True)
+class CompositeSource:
+    cam_name: str
+    path: Optional[Path]
+    pre_roll_frames: int
+
+
+@dataclass(frozen=True)
+class CompositeJob:
+    event_id: str
+    part_number: int
+    part_start_ts: datetime.datetime
+    sources: List[CompositeSource]
+    out_dir: Path
+    save_prefix: str
+    fps: float
+    sonar: bool
+
+
+def composite_output_path(job: CompositeJob) -> Path:
+    """Reserve a canonical output name without ever overwriting a clip."""
+    if job.part_start_ts.tzinfo is None:
+        raise ValueError("CompositeJob.part_start_ts must be timezone-aware")
+
+    timestamp = job.part_start_ts.astimezone().strftime("%Y%m%d_%H%M%S")
+    base = f"{job.save_prefix}_{timestamp}"
+    filename = Path(job.out_dir) / f"{base}_M.mp4"
+    if not filename.exists():
+        return filename
+
+    collided = filename
+    now_tag = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y%m%dT%H%M%S%fZ"
+    )
+    filename = Path(job.out_dir) / f"collision_{base}_{now_tag}_M.mp4"
+    while filename.exists():
+        token = secrets.token_hex(2)
+        filename = Path(job.out_dir) / (
+            f"collision_{base}_{now_tag}_{token}_M.mp4"
+        )
+    logger.error(
+        "Composite path already exists (unexpected collision): %s; preserving "
+        "it and writing the new clip to %s",
+        collided,
+        filename,
+    )
+    return filename
+
+
+def _effective_source_duration(source: CompositeSource, trim_frames: int, fps: float) -> float:
+    if source.path is None:
+        return 0.0
+    metadata = utils.get_video_metadata(source.path)
+    if metadata is None:
+        raise RuntimeError(f"Could not probe composite source: {source.path}")
+    return max(0.0, metadata.duration - (trim_frames / fps))
+
+
+def build_ffmpeg_cmd(job: CompositeJob, out_path: Path) -> List[str]:
+    """Build the ffmpeg command for a frame-aligned vertical composition."""
+    if not job.sources:
+        raise ValueError("CompositeJob.sources must not be empty")
+    if job.fps <= 0:
+        raise ValueError(f"CompositeJob.fps must be positive, got {job.fps}")
+
+    present = [source for source in job.sources if source.path is not None]
+    if not present:
+        raise ValueError("At least one composite source must be present")
+
+    p_min = min(source.pre_roll_frames for source in present)
+    trims = [
+        max(0, source.pre_roll_frames - p_min) if source.path is not None else 0
+        for source in job.sources
+    ]
+    durations = [
+        _effective_source_duration(source, trim, job.fps)
+        for source, trim in zip(job.sources, trims)
+        if source.path is not None
+    ]
+    max_duration = max(durations)
+    if max_duration <= 0:
+        raise RuntimeError("Composite sources have no video after pre-roll trimming")
+
+    fps_str = f"{job.fps:g}"
+    cmd = ["ffmpeg", "-hide_banner", "-y", "-fflags", "+genpts"]
+    for source in job.sources:
+        if source.path is None:
+            cmd.extend([
+                "-f",
+                "lavfi",
+                "-t",
+                f"{max_duration:.6f}",
+                "-i",
+                f"color=c=black:s=1280x720:r={fps_str}",
+            ])
+        else:
+            cmd.extend(["-i", str(source.path)])
+
+    filters = []
+    for index, trim in enumerate(trims):
+        filters.append(
+            f"[{index}:v]trim=start_frame={trim},setpts=PTS-STARTPTS,"
+            f"scale=1280:-2,setsar=1,fps={fps_str}[v{index}]"
+        )
+    inputs = "".join(f"[v{index}]" for index in range(len(job.sources)))
+    filters.append(f"{inputs}vstack=inputs={len(job.sources)}[outv]")
+
+    cmd.extend([
+        "-filter_complex",
+        ";".join(filters),
+        "-map",
+        "[outv]",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-crf",
+        "23",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        "-an",
+        "-avoid_negative_ts",
+        "make_zero",
+        "-threads",
+        "2",
+        str(out_path),
+    ])
+    return cmd
+
+
+def _parts_metadata_path(source_path: Path) -> Path:
+    return (
+        source_path.parent.parent
+        / MOTION_VIDS_PARTS_METADATA
+        / f"{source_path.stem}.json"
+    )
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as file_obj:
+        json.dump(payload, file_obj, indent=4)
+
+
+def run_composite(job: CompositeJob) -> Path:
+    """Create, probe, publish, and clean up one composite job."""
+    job.out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = composite_output_path(job)
+    tmp_path = out_path.with_name(f".{out_path.stem}.tmp.mp4")
+    cmd = build_ffmpeg_cmd(job, tmp_path)
+
+    logger.info(
+        "Compositing event=%s part=%d cameras=%s to %s",
+        job.event_id,
+        job.part_number,
+        [source.cam_name for source in job.sources],
+        out_path,
+    )
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            preexec_fn=lambda: os.nice(10),
+        )
+        os.replace(tmp_path, out_path)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+    metadata = utils.get_video_metadata(out_path)
+    if metadata is None:
+        raise RuntimeError(f"Could not probe completed composite: {out_path}")
+
+    present = [source for source in job.sources if source.path is not None]
+    p_min = min(source.pre_roll_frames for source in present)
+    pre_roll_trim = [
+        max(0, source.pre_roll_frames - p_min) if source.path is not None else 0
+        for source in job.sources
+    ]
+    payload = asdict(metadata)
+    payload.update({
+        "event_id": job.event_id,
+        "part_number": job.part_number,
+        "part_start_ts": job.part_start_ts.isoformat(),
+        "cam_order": [source.cam_name for source in job.sources],
+        "layout": "vstack",
+        "source_clips": [
+            str(source.path) if source.path is not None else None
+            for source in job.sources
+        ],
+        "pre_roll_trim": pre_roll_trim,
+    })
+    metadata_path = (
+        out_path.parent.parent / MOTION_VIDS_METADATA_DIR / f"{out_path.stem}.json"
+    )
+    _write_json(metadata_path, payload)
+
+    if job.sonar:
+        # Import lazily to avoid a module cycle: motion_detect_stream imports
+        # CompositeJob for its completion barrier.
+        from pysalmcount.motion_detect_stream import SONAR_DEVICE_SETTINGS, VideoSaver
+
+        settings_path = VideoSaver.filename_to_device_settings_filepath(out_path)
+        _write_json(settings_path, SONAR_DEVICE_SETTINGS)
+
+    for source in present:
+        assert source.path is not None
+        metadata_path = _parts_metadata_path(source.path)
+        try:
+            source.path.unlink()
+        except FileNotFoundError:
+            logger.warning("Composite source was already absent: %s", source.path)
+        try:
+            metadata_path.unlink()
+        except FileNotFoundError:
+            logger.warning("Composite source metadata was absent: %s", metadata_path)
+
+    logger.info("Composite complete: %s", out_path)
+    return out_path
+
+
+class CompositorWorker(Process):
+    """Serialize ffmpeg work so composite jobs cannot compete with each other."""
+
+    def __init__(self, job_queue):
+        super().__init__(name="ClipCompositor", daemon=False)
+        self.job_queue = job_queue
+
+    def run(self) -> None:
+        while True:
+            job = self.job_queue.get()
+            if job is None:
+                return
+            try:
+                run_composite(job)
+            except Exception:
+                logger.exception(
+                    "Composite failed for event=%s part=%s; source clips retained",
+                    getattr(job, "event_id", "unknown"),
+                    getattr(job, "part_number", "unknown"),
+                )
+
+
+def _cam_name_from_head(head: str, cam_names: Sequence[str]) -> Optional[str]:
+    for cam_name in sorted(cam_names, key=len, reverse=True):
+        if head == cam_name or head.endswith(f"_{cam_name}"):
+            return cam_name
+    return None
+
+
+def find_stale_composite_jobs(
+    parts_dir: Path,
+    cam_names: Sequence[str],
+    out_dir: Path,
+    save_prefix: str,
+    fps: float,
+    sonar: bool,
+    stale_after_seconds: float,
+    *,
+    now: Optional[float] = None,
+) -> List[CompositeJob]:
+    """Recover complete per-camera clips left behind by a prior process."""
+    parts_dir = Path(parts_dir)
+    if not parts_dir.exists():
+        return []
+    if now is None:
+        now = datetime.datetime.now().timestamp()
+
+    groups = {}
+    for path in sorted(parts_dir.glob("*_M.mp4")):
+        match = PART_TAIL_RE.search(path.name)
+        if match is None:
+            logger.warning("Ignoring unrecognized composite part filename: %s", path)
+            continue
+        head = path.name[:match.start()]
+        cam_name = _cam_name_from_head(head, cam_names)
+        if cam_name is None:
+            logger.warning("Could not recover camera name from composite part: %s", path)
+            continue
+        tail_event = match.group("event")
+        tail_part = int(match.group("part"))
+        tail_date = match.group("date")
+        tail_time = match.group("time")
+
+        event_id = None
+        part_start_ts = None
+        pre_roll_frames = 0
+        metadata_path = _parts_metadata_path(path)
+        try:
+            with open(metadata_path) as file_obj:
+                metadata = json.load(file_obj)
+            event_id = str(metadata["event_id"])
+            part_number = int(metadata["part_number"])
+            part_start_ts = datetime.datetime.fromisoformat(metadata["part_start_ts"])
+            pre_roll_frames = int(metadata["pre_roll_frames"])
+        except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+            event_id = None
+            part_start_ts = None
+            pre_roll_frames = 0
+            logger.warning(
+                "Recovering stale composite part without usable metadata; "
+                "pre-roll trim defaults to zero: %s",
+                path,
+            )
+        else:
+            if part_number != tail_part:
+                logger.error(
+                    "Parts metadata disagrees with filename for %s; using "
+                    "filename part=%d instead of metadata part=%d",
+                    path,
+                    tail_part,
+                    part_number,
+                )
+            if part_start_ts.tzinfo is None:
+                logger.error(
+                    "Parts metadata has naive part_start_ts for %s; using "
+                    "the filename timestamp",
+                    path,
+                )
+                part_start_ts = None
+
+        key = (tail_event, tail_part, tail_date, tail_time)
+        group = groups.setdefault(key, {
+            "event_ids": set(),
+            "part_start_ts": None,
+            "sources": {},
+            "mtimes": [],
+        })
+        if event_id is not None:
+            group["event_ids"].add(event_id)
+        if part_start_ts is not None:
+            group["part_start_ts"] = part_start_ts.astimezone(
+                datetime.timezone.utc
+            )
+        group["sources"][cam_name] = CompositeSource(
+            cam_name=cam_name,
+            path=path,
+            pre_roll_frames=pre_roll_frames,
+        )
+        group["mtimes"].append(path.stat().st_mtime)
+
+    jobs = []
+    for (tail_event, part_number, tail_date, tail_time), group in sorted(
+        groups.items()
+    ):
+        if any(
+            now - mtime < stale_after_seconds
+            for mtime in group["mtimes"]
+        ):
+            continue
+        if len(group["event_ids"]) > 1:
+            logger.error(
+                "Ignoring stale part group with conflicting event IDs: %s",
+                sorted(group["event_ids"]),
+            )
+            continue
+        event_id = next(
+            iter(group["event_ids"]),
+            f"recovered_{tail_date}T{tail_time}_{tail_event}",
+        )
+        part_start_ts = group["part_start_ts"] or datetime.datetime.strptime(
+            f"{tail_date}_{tail_time}", "%Y%m%d_%H%M%S"
+        ).astimezone().astimezone(datetime.timezone.utc)
+        present_sources = list(group["sources"].values())
+        missing_pre_roll = min(
+            (source.pre_roll_frames for source in present_sources),
+            default=0,
+        )
+        sources = [
+            group["sources"].get(
+                cam_name,
+                CompositeSource(cam_name, None, missing_pre_roll),
+            )
+            for cam_name in cam_names
+        ]
+        jobs.append(CompositeJob(
+            event_id=event_id,
+            part_number=part_number,
+            part_start_ts=part_start_ts,
+            sources=sources,
+            out_dir=Path(out_dir),
+            save_prefix=save_prefix,
+            fps=float(fps),
+            sonar=bool(sonar),
+        ))
+    return jobs

--- a/training/pysalmcount/pysalmcount/clip_compositor.py
+++ b/training/pysalmcount/pysalmcount/clip_compositor.py
@@ -33,7 +33,6 @@ PART_TAIL_RE = re.compile(
 class CompositeSource:
     cam_name: str
     path: Optional[Path]
-    pre_roll_frames: int
 
 
 @dataclass(frozen=True)
@@ -46,6 +45,15 @@ class CompositeJob:
     save_prefix: str
     fps: float
     sonar: bool
+
+
+@dataclass(frozen=True)
+class EndAlignment:
+    """Frame counts and leading trims needed to align source endings."""
+
+    source_frame_counts: List[Optional[int]]
+    start_frame_trims: List[int]
+    aligned_frame_count: int
 
 
 def composite_output_path(job: CompositeJob) -> Path:
@@ -78,41 +86,62 @@ def composite_output_path(job: CompositeJob) -> Path:
     return filename
 
 
-def _effective_source_duration(source: CompositeSource, trim_frames: int, fps: float) -> float:
-    if source.path is None:
-        return 0.0
-    metadata = utils.get_video_metadata(source.path)
-    if metadata is None:
-        raise RuntimeError(f"Could not probe composite source: {source.path}")
-    return max(0.0, metadata.duration - (trim_frames / fps))
+def calculate_end_alignment(job: CompositeJob) -> EndAlignment:
+    """Calculate leading trims so every present source ends together."""
+    if not job.sources:
+        raise ValueError("CompositeJob.sources must not be empty")
+
+    source_frame_counts: List[Optional[int]] = []
+    for source in job.sources:
+        if source.path is None:
+            source_frame_counts.append(None)
+            continue
+        metadata = utils.get_video_metadata(source.path)
+        if metadata is None:
+            raise RuntimeError(f"Could not probe composite source: {source.path}")
+        if metadata.nb_frames <= 0:
+            raise RuntimeError(
+                f"Composite source has no frames: {source.path}"
+            )
+        source_frame_counts.append(metadata.nb_frames)
+
+    present_frame_counts = [
+        frame_count
+        for frame_count in source_frame_counts
+        if frame_count is not None
+    ]
+    if not present_frame_counts:
+        raise ValueError("At least one composite source must be present")
+
+    aligned_frame_count = min(present_frame_counts)
+    start_frame_trims = [
+        frame_count - aligned_frame_count
+        if frame_count is not None else 0
+        for frame_count in source_frame_counts
+    ]
+    return EndAlignment(
+        source_frame_counts=source_frame_counts,
+        start_frame_trims=start_frame_trims,
+        aligned_frame_count=aligned_frame_count,
+    )
 
 
-def build_ffmpeg_cmd(job: CompositeJob, out_path: Path) -> List[str]:
-    """Build the ffmpeg command for a frame-aligned vertical composition."""
+def build_ffmpeg_cmd(
+    job: CompositeJob,
+    out_path: Path,
+    alignment: Optional[EndAlignment] = None,
+) -> List[str]:
+    """Build an ffmpeg command that aligns all source clips by their ends."""
     if not job.sources:
         raise ValueError("CompositeJob.sources must not be empty")
     if job.fps <= 0:
         raise ValueError(f"CompositeJob.fps must be positive, got {job.fps}")
 
-    present = [source for source in job.sources if source.path is not None]
-    if not present:
-        raise ValueError("At least one composite source must be present")
-
-    p_min = min(source.pre_roll_frames for source in present)
-    trims = [
-        max(0, source.pre_roll_frames - p_min) if source.path is not None else 0
-        for source in job.sources
-    ]
-    durations = [
-        _effective_source_duration(source, trim, job.fps)
-        for source, trim in zip(job.sources, trims)
-        if source.path is not None
-    ]
-    max_duration = max(durations)
-    if max_duration <= 0:
-        raise RuntimeError("Composite sources have no video after pre-roll trimming")
+    if alignment is None:
+        alignment = calculate_end_alignment(job)
 
     fps_str = f"{job.fps:g}"
+    aligned_duration = alignment.aligned_frame_count / job.fps
     cmd = ["ffmpeg", "-hide_banner", "-y", "-fflags", "+genpts"]
     for source in job.sources:
         if source.path is None:
@@ -120,7 +149,7 @@ def build_ffmpeg_cmd(job: CompositeJob, out_path: Path) -> List[str]:
                 "-f",
                 "lavfi",
                 "-t",
-                f"{max_duration:.6f}",
+                f"{aligned_duration:.6f}",
                 "-i",
                 f"color=c=black:s=1280x720:r={fps_str}",
             ])
@@ -128,13 +157,24 @@ def build_ffmpeg_cmd(job: CompositeJob, out_path: Path) -> List[str]:
             cmd.extend(["-i", str(source.path)])
 
     filters = []
-    for index, trim in enumerate(trims):
+    for index, (trim, frame_count) in enumerate(zip(
+        alignment.start_frame_trims,
+        alignment.source_frame_counts,
+    )):
+        end_frame = (
+            frame_count
+            if frame_count is not None
+            else alignment.aligned_frame_count
+        )
         filters.append(
-            f"[{index}:v]trim=start_frame={trim},setpts=PTS-STARTPTS,"
+            f"[{index}:v]trim=start_frame={trim}:end_frame={end_frame},"
+            "setpts=PTS-STARTPTS,"
             f"scale=1280:-2,setsar=1,fps={fps_str}[v{index}]"
         )
     inputs = "".join(f"[v{index}]" for index in range(len(job.sources)))
-    filters.append(f"{inputs}vstack=inputs={len(job.sources)}[outv]")
+    filters.append(
+        f"{inputs}vstack=inputs={len(job.sources)}:shortest=1[outv]"
+    )
 
     cmd.extend([
         "-filter_complex",
@@ -156,6 +196,8 @@ def build_ffmpeg_cmd(job: CompositeJob, out_path: Path) -> List[str]:
         "make_zero",
         "-threads",
         "2",
+        "-frames:v",
+        str(alignment.aligned_frame_count),
         str(out_path),
     ])
     return cmd
@@ -180,7 +222,8 @@ def run_composite(job: CompositeJob) -> Path:
     job.out_dir.mkdir(parents=True, exist_ok=True)
     out_path = composite_output_path(job)
     tmp_path = out_path.with_name(f".{out_path.stem}.tmp.mp4")
-    cmd = build_ffmpeg_cmd(job, tmp_path)
+    alignment = calculate_end_alignment(job)
+    cmd = build_ffmpeg_cmd(job, tmp_path, alignment=alignment)
 
     logger.info(
         "Compositing event=%s part=%d cameras=%s to %s",
@@ -208,11 +251,6 @@ def run_composite(job: CompositeJob) -> Path:
         raise RuntimeError(f"Could not probe completed composite: {out_path}")
 
     present = [source for source in job.sources if source.path is not None]
-    p_min = min(source.pre_roll_frames for source in present)
-    pre_roll_trim = [
-        max(0, source.pre_roll_frames - p_min) if source.path is not None else 0
-        for source in job.sources
-    ]
     payload = asdict(metadata)
     payload.update({
         "event_id": job.event_id,
@@ -224,7 +262,10 @@ def run_composite(job: CompositeJob) -> Path:
             str(source.path) if source.path is not None else None
             for source in job.sources
         ],
-        "pre_roll_trim": pre_roll_trim,
+        "frame_alignment": "end",
+        "source_frame_counts": alignment.source_frame_counts,
+        "start_frame_trim": alignment.start_frame_trims,
+        "aligned_frame_count": alignment.aligned_frame_count,
     })
     metadata_path = (
         out_path.parent.parent / MOTION_VIDS_METADATA_DIR / f"{out_path.stem}.json"
@@ -320,7 +361,6 @@ def find_stale_composite_jobs(
 
         event_id = None
         part_start_ts = None
-        pre_roll_frames = 0
         metadata_path = _parts_metadata_path(path)
         try:
             with open(metadata_path) as file_obj:
@@ -328,14 +368,12 @@ def find_stale_composite_jobs(
             event_id = str(metadata["event_id"])
             part_number = int(metadata["part_number"])
             part_start_ts = datetime.datetime.fromisoformat(metadata["part_start_ts"])
-            pre_roll_frames = int(metadata["pre_roll_frames"])
         except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
             event_id = None
             part_start_ts = None
-            pre_roll_frames = 0
             logger.warning(
                 "Recovering stale composite part without usable metadata; "
-                "pre-roll trim defaults to zero: %s",
+                "event identity falls back to its filename: %s",
                 path,
             )
         else:
@@ -371,7 +409,6 @@ def find_stale_composite_jobs(
         group["sources"][cam_name] = CompositeSource(
             cam_name=cam_name,
             path=path,
-            pre_roll_frames=pre_roll_frames,
         )
         group["mtimes"].append(path.stat().st_mtime)
 
@@ -397,15 +434,10 @@ def find_stale_composite_jobs(
         part_start_ts = group["part_start_ts"] or datetime.datetime.strptime(
             f"{tail_date}_{tail_time}", "%Y%m%d_%H%M%S"
         ).astimezone().astimezone(datetime.timezone.utc)
-        present_sources = list(group["sources"].values())
-        missing_pre_roll = min(
-            (source.pre_roll_frames for source in present_sources),
-            default=0,
-        )
         sources = [
             group["sources"].get(
                 cam_name,
-                CompositeSource(cam_name, None, missing_pre_roll),
+                CompositeSource(cam_name, None),
             )
             for cam_name in cam_names
         ]

--- a/training/pysalmcount/pysalmcount/motion_detect_stream.py
+++ b/training/pysalmcount/pysalmcount/motion_detect_stream.py
@@ -367,11 +367,6 @@ class MotionEventCoordinator:
                 "MotionEventCoordinator compositing settings were not configured"
             )
 
-        present_pre_roll = [
-            int(result["pre_roll_frames"])
-            for result in pending.results.values()
-        ]
-        missing_pre_roll = min(present_pre_roll, default=0)
         sources = []
         for cam_name in self._cam_names:
             result = pending.results.get(cam_name)
@@ -379,13 +374,11 @@ class MotionEventCoordinator:
                 sources.append(CompositeSource(
                     cam_name=cam_name,
                     path=None,
-                    pre_roll_frames=missing_pre_roll,
                 ))
             else:
                 sources.append(CompositeSource(
                     cam_name=cam_name,
                     path=Path(result["path"]),
-                    pre_roll_frames=int(result["pre_roll_frames"]),
                 ))
         return CompositeJob(
             event_id=pending.clip_info.event_id,

--- a/training/pysalmcount/pysalmcount/motion_detect_stream.py
+++ b/training/pysalmcount/pysalmcount/motion_detect_stream.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from .dataloader import DataLoader
+from .clip_compositor import CompositeJob, CompositeSource
 from pysalmcount import utils
 
 import cv2
@@ -31,7 +32,10 @@ gst_raspi_writer_str = "appsrc ! video/x-raw,format=BGR ! queue ! videoconvert !
 MOTION_VIDS = 'motion_vids'
 MOTION_VIDS_STAGING = 'motion_vids_staging'
 MOTION_VIDS_METADATA_DIR = 'motion_vids_metadata'
+MOTION_VIDS_PARTS = 'motion_vids_parts'
+MOTION_VIDS_PARTS_METADATA = 'motion_vids_parts_metadata'
 DEVICE_SETTINGS_DIR = 'device_settings'
+COMPOSITE_TIMEOUT_SECONDS = 180.0
 
 # Placeholder settings used by downstream sonar processing. A same-stem JSON
 # file is written into DEVICE_SETTINGS_DIR for each completed motion clip when
@@ -76,6 +80,14 @@ class ClipInfo:
     event_start_ts: datetime.datetime
     part_number: int
     originator: str
+    part_start_ts: Optional[datetime.datetime] = None
+
+
+@dataclass
+class _PendingPart:
+    clip_info: ClipInfo
+    first_report_wall: float
+    results: Dict[str, dict]
 
 
 class MotionEventCoordinator:
@@ -94,7 +106,13 @@ class MotionEventCoordinator:
 
     def __init__(self, cam_names: List[str],
                  max_clip_seconds: float = MAX_CLIP_SECONDS,
-                 post_roll_seconds: float = POST_ROLL_SECONDS):
+                 post_roll_seconds: float = POST_ROLL_SECONDS,
+                 *,
+                 composite_out_dir: Optional[Path] = None,
+                 composite_save_prefix: Optional[str] = None,
+                 composite_fps: Optional[float] = None,
+                 composite_sonar: bool = False,
+                 composite_timeout_seconds: float = COMPOSITE_TIMEOUT_SECONDS):
         if len(cam_names) < 2:
             raise ValueError(
                 "MotionEventCoordinator requires N >= 2 cameras, got "
@@ -121,6 +139,7 @@ class MotionEventCoordinator:
         self._current_part_number: int = 0
         # time.monotonic() timestamps for drift-free shared timing.
         self._current_part_start_wall: Optional[float] = None
+        self._current_part_start_utc: Optional[datetime.datetime] = None
         self._last_motion_wall: Optional[float] = None
         self._cams_recording: Set[str] = set()
         # Set True the instant a finalize is broadcast (in tick) and cleared
@@ -131,6 +150,19 @@ class MotionEventCoordinator:
         self._finalizing: bool = False
         self._max_clip_seconds = float(max_clip_seconds)
         self._post_roll_seconds = float(post_roll_seconds)
+        self._composite_out_dir = (
+            Path(composite_out_dir) if composite_out_dir is not None else None
+        )
+        self._composite_save_prefix = composite_save_prefix
+        self._composite_fps = (
+            float(composite_fps) if composite_fps is not None else None
+        )
+        self._composite_sonar = bool(composite_sonar)
+        self._composite_timeout_seconds = float(composite_timeout_seconds)
+        # Completed clips arrive after leave_event(), so this barrier is kept
+        # independent from the active recording set.
+        self._pending_parts: Dict[Tuple[str, int], _PendingPart] = {}
+        self._emitted_parts: Set[Tuple[str, int]] = set()
 
     @staticmethod
     def _mint_event_id(now_utc: datetime.datetime) -> str:
@@ -168,7 +200,7 @@ class MotionEventCoordinator:
             if self._active_event_id is None:
                 # Mint.
                 now_wall = time.monotonic()
-                now_utc = datetime.datetime.utcnow()
+                now_utc = datetime.datetime.now(datetime.timezone.utc)
                 assert cam_name not in self._cams_recording, (
                     f"enter_event mint called but {cam_name} is already "
                     f"recording (coordinator state corrupted?)"
@@ -178,6 +210,7 @@ class MotionEventCoordinator:
                 self._event_originator = cam_name
                 self._current_part_number = 1
                 self._current_part_start_wall = now_wall
+                self._current_part_start_utc = now_utc
                 self._last_motion_wall = now_wall
                 self._finalizing = False
                 # Fan out to every other cam. Clear this cam's own flag below.
@@ -194,6 +227,7 @@ class MotionEventCoordinator:
                 event_id=self._active_event_id,
                 event_start_ts=self._active_event_start,
                 part_number=self._current_part_number,
+                part_start_ts=self._current_part_start_utc,
                 originator=self._event_originator,
             )
 
@@ -210,6 +244,7 @@ class MotionEventCoordinator:
                 event_id=self._active_event_id,
                 event_start_ts=self._active_event_start,
                 part_number=self._current_part_number,
+                part_start_ts=self._current_part_start_utc,
                 originator=self._event_originator,
             )
 
@@ -275,6 +310,9 @@ class MotionEventCoordinator:
                     now_wall - self._current_part_start_wall >= self._max_clip_seconds):
                 self._current_part_number += 1
                 self._current_part_start_wall = now_wall
+                self._current_part_start_utc = datetime.datetime.now(
+                    datetime.timezone.utc
+                )
                 for n in self._cam_names:
                     self._rollover_pending[n] = True
                 # Consume this cam's bit immediately.
@@ -309,6 +347,7 @@ class MotionEventCoordinator:
                 self._event_originator = None
                 self._current_part_number = 0
                 self._current_part_start_wall = None
+                self._current_part_start_utc = None
                 self._last_motion_wall = None
                 self._finalizing = False
                 for n in self._cam_names:
@@ -319,6 +358,103 @@ class MotionEventCoordinator:
     def is_event_active(self) -> bool:
         with self._lock:
             return self._active_event_id is not None
+
+    def _build_composite_job(self, pending: _PendingPart) -> CompositeJob:
+        if (self._composite_out_dir is None or
+                self._composite_save_prefix is None or
+                self._composite_fps is None):
+            raise RuntimeError(
+                "MotionEventCoordinator compositing settings were not configured"
+            )
+
+        present_pre_roll = [
+            int(result["pre_roll_frames"])
+            for result in pending.results.values()
+        ]
+        missing_pre_roll = min(present_pre_roll, default=0)
+        sources = []
+        for cam_name in self._cam_names:
+            result = pending.results.get(cam_name)
+            if result is None:
+                sources.append(CompositeSource(
+                    cam_name=cam_name,
+                    path=None,
+                    pre_roll_frames=missing_pre_roll,
+                ))
+            else:
+                sources.append(CompositeSource(
+                    cam_name=cam_name,
+                    path=Path(result["path"]),
+                    pre_roll_frames=int(result["pre_roll_frames"]),
+                ))
+        return CompositeJob(
+            event_id=pending.clip_info.event_id,
+            part_number=pending.clip_info.part_number,
+            part_start_ts=(
+                pending.clip_info.part_start_ts
+                or pending.clip_info.event_start_ts
+            ),
+            sources=sources,
+            out_dir=self._composite_out_dir,
+            save_prefix=self._composite_save_prefix,
+            fps=self._composite_fps,
+            sonar=self._composite_sonar,
+        )
+
+    def report_part_finished(
+        self,
+        cam_name: str,
+        clip_info: ClipInfo,
+        result: dict,
+    ) -> Optional[CompositeJob]:
+        """Add one finished camera clip and emit when the part is complete."""
+        if cam_name not in self._cam_names:
+            raise ValueError(f"Unknown cam_name: {cam_name!r}")
+        key = (clip_info.event_id, clip_info.part_number)
+        with self._lock:
+            if key in self._emitted_parts:
+                logger.warning(
+                    "Ignoring late/duplicate clip report for event=%s part=%d cam=%s",
+                    clip_info.event_id,
+                    clip_info.part_number,
+                    cam_name,
+                )
+                return None
+            pending = self._pending_parts.get(key)
+            if pending is None:
+                pending = _PendingPart(
+                    clip_info=clip_info,
+                    first_report_wall=time.monotonic(),
+                    results={},
+                )
+                self._pending_parts[key] = pending
+            pending.results[cam_name] = dict(result)
+            if len(pending.results) < len(self._cam_names):
+                return None
+
+            job = self._build_composite_job(pending)
+            del self._pending_parts[key]
+            self._emitted_parts.add(key)
+            return job
+
+    def reap_stale_parts(self, force: bool = False) -> List[CompositeJob]:
+        """Emit timed-out partial groups with black rows for missing cameras."""
+        now_wall = time.monotonic()
+        jobs = []
+        with self._lock:
+            stale_keys = [
+                key
+                for key, pending in self._pending_parts.items()
+                if force or (
+                    now_wall - pending.first_report_wall
+                    >= self._composite_timeout_seconds
+                )
+            ]
+            for key in stale_keys:
+                pending = self._pending_parts.pop(key)
+                jobs.append(self._build_composite_job(pending))
+                self._emitted_parts.add(key)
+        return jobs
 
 
 def build_cpu_h264_writer(
@@ -394,11 +530,14 @@ class VideoSaver(Process):
             event_id: Optional[str] = None,
             event_start_ts: Optional[datetime.datetime] = None,
             part_number: Optional[int] = None,
+            part_start_ts: Optional[datetime.datetime] = None,
             cam_name: Optional[str] = None,
             triggered_by: Optional[str] = None,
             cpu_h264=False,
             cpu_h264_bitrate=1200,
             sonar=False,
+            composite_mode=False,
+            result_q: Optional[Queue] = None,
             ):
         super().__init__()
         self.frame_shape = frame_shape
@@ -424,11 +563,14 @@ class VideoSaver(Process):
         self.event_id = event_id
         self.event_start_ts = event_start_ts
         self.part_number = part_number
+        self.part_start_ts = part_start_ts
         self.cam_name = cam_name
         self.triggered_by = triggered_by
         self.cpu_h264 = cpu_h264
         self.cpu_h264_bitrate = cpu_h264_bitrate
         self.sonar = sonar
+        self.composite_mode = composite_mode
+        self.result_q = result_q
 
         if is_video and filename is None:
             logger.warn("Filename is empty. Will fallback on timestampped name")
@@ -452,7 +594,11 @@ class VideoSaver(Process):
         # so every clip of one episode groups together and per-cam rolled
         # segments stay ordered. `save_prefix` already carries the cam name.
         if self.event_id is not None and self.event_start_ts is not None:
-            ts = self.event_start_ts.strftime("%Y%m%d_%H%M%S")
+            if self.composite_mode:
+                clip_ts = self.part_start_ts or self.event_start_ts
+                ts = clip_ts.astimezone().strftime("%Y%m%d_%H%M%S")
+            else:
+                ts = self.event_start_ts.strftime("%Y%m%d_%H%M%S")
             short = MotionEventCoordinator.event_id_short(self.event_id)
             part = self.part_number if self.part_number is not None else 1
             prefix = save_prefix if save_prefix is not None else os.uname()[1]
@@ -521,9 +667,12 @@ class VideoSaver(Process):
         return filename
 
     @staticmethod
-    def filename_to_metadata_filepath(filename: Path) -> Path:
-        metadata_dir = filename.parent.parent / MOTION_VIDS_METADATA_DIR
-        metadata_dir.mkdir(exist_ok=True)
+    def filename_to_metadata_filepath(
+        filename: Path,
+        metadata_dir_name: str = MOTION_VIDS_METADATA_DIR,
+    ) -> Path:
+        metadata_dir = filename.parent.parent / metadata_dir_name
+        metadata_dir.mkdir(exist_ok=True, parents=True)
         return metadata_dir / f"{filename.stem}.json"
 
     @staticmethod
@@ -607,6 +756,7 @@ class VideoSaver(Process):
             out.write(frame)
             c += 1
 
+        pre_roll_frames = c
         c = 0
         # Continue recording until stop_event is set
         while True:
@@ -635,7 +785,7 @@ class VideoSaver(Process):
         # Sonar deployments need a small per-clip settings file to trigger
         # downstream sonar processing. Keep the same stem as the motion clip and
         # place it at the device level under device_settings/.
-        if self.sonar:
+        if self.sonar and not self.composite_mode:
             try:
                 settings_filepath = VideoSaver.filename_to_device_settings_filepath(
                     Path(filename)
@@ -677,10 +827,23 @@ class VideoSaver(Process):
                 "cam_name": self.cam_name,
                 "triggered_by": self.triggered_by,
                 "part_number": self.part_number,
+                "part_start_ts": (
+                    self.part_start_ts.isoformat()
+                    if self.part_start_ts is not None else None
+                ),
+                "pre_roll_frames": pre_roll_frames,
             })
 
         if payload:
-            metadata_filepath = VideoSaver.filename_to_metadata_filepath(Path(filename))
+            metadata_dir_name = (
+                MOTION_VIDS_PARTS_METADATA
+                if self.composite_mode
+                else MOTION_VIDS_METADATA_DIR
+            )
+            metadata_filepath = VideoSaver.filename_to_metadata_filepath(
+                Path(filename),
+                metadata_dir_name=metadata_dir_name,
+            )
             logger.info(f"Saving metadata file to harddrive: {str(metadata_filepath)}")
             with open(str(metadata_filepath), 'w') as f:
                 json.dump(payload, f)
@@ -689,6 +852,15 @@ class VideoSaver(Process):
             logger.error(f"Could not generate metadata for file: {filename}")
             logger.error(tb)
             self.status_q.put((ERROR_CODE, ("", tb)))
+
+        if self.composite_mode and self.result_q is not None:
+            self.result_q.put({
+                "path": Path(filename),
+                "cam_name": self.cam_name,
+                "event_id": self.event_id,
+                "part_number": self.part_number,
+                "pre_roll_frames": pre_roll_frames,
+            })
 
 
 class OutputFileHealth:
@@ -747,7 +919,9 @@ class MotionDetector:
 
     def __init__(self, dataloader: DataLoader, save_folder, save_video=True, save_cont_video=True, is_video=False, save_prefix=None, ping_url='https://google.com',
                  coordinator: Optional[MotionEventCoordinator] = None,
-                 cam_name: Optional[str] = None):
+                 cam_name: Optional[str] = None,
+                 composite: bool = False,
+                 composite_queue=None):
         self.dataloader = dataloader
         self.save_folder = save_folder
         self.frame_log = {}
@@ -764,7 +938,10 @@ class MotionDetector:
         # with exact legacy behavior.
         self.coordinator = coordinator
         self.cam_name = cam_name
+        self.composite = bool(composite)
+        self.composite_queue = composite_queue
         self._awaiting_next_part: bool = False
+        self._video_saver_clip_infos: Dict[Tuple[str, int], ClipInfo] = {}
         # Per-cam log adapter so every record is tagged with [cam_name] in
         # multi-cam mode. In single-cam mode fall back to the module logger.
         if cam_name is not None:
@@ -779,6 +956,54 @@ class MotionDetector:
         self.lock_tail = Lock()
         self.condition = Condition()
         self.status_q = Queue()
+        self.result_q = Queue()
+
+    def _collect_finished_clip(self, wait_for_result: bool = False) -> None:
+        """Forward successful VideoSaver results through the part barrier."""
+        if not self.composite:
+            return
+        if self.coordinator is None or self.composite_queue is None:
+            raise RuntimeError("Composite mode requires a coordinator and queue")
+
+        first = True
+        while True:
+            try:
+                if first and wait_for_result:
+                    result = self.result_q.get(timeout=1.0)
+                else:
+                    result = self.result_q.get_nowait()
+            except queue.Empty:
+                break
+            first = False
+            key = (str(result["event_id"]), int(result["part_number"]))
+            clip_info = self._video_saver_clip_infos.pop(key, None)
+            if clip_info is None:
+                self.log.error(
+                    "No ClipInfo retained for finished event=%s part=%s",
+                    key[0],
+                    key[1],
+                )
+                continue
+            job = self.coordinator.report_part_finished(
+                str(result["cam_name"]),
+                clip_info,
+                result,
+            )
+            if job is not None:
+                self.composite_queue.put(job)
+
+    def _enqueue_stale_composites(self) -> None:
+        if not self.composite:
+            return
+        if self.coordinator is None or self.composite_queue is None:
+            return
+        for job in self.coordinator.reap_stale_parts():
+            self.log.warning(
+                "Compositing stale event=%s part=%d with missing camera rows",
+                job.event_id,
+                job.part_number,
+            )
+            self.composite_queue.put(job)
 
     def _raise_if_video_saver_failed(self):
         while True:
@@ -861,6 +1086,11 @@ class MotionDetector:
                     self.video_saver.terminate()
                     self.video_saver.join(timeout=5)
 
+            saver_succeeded = (
+                self.video_saver is not None and self.video_saver.exitcode == 0
+            )
+            self._collect_finished_clip(wait_for_result=saver_succeeded)
+
             self.video_saver = None
             self.video_saver_stop_event = None
             self.motion_detected = False
@@ -882,24 +1112,30 @@ class MotionDetector:
         back to today's timestamp-based filename.
         """
         # Safety guard: do not start a new saver while the old one is alive.
-        if self.video_saver is not None and self.video_saver.is_alive():
-            self.log.warning(
-                "Previous VideoSaver still alive; joining before spawning a new one. pid=%s",
-                self.video_saver.pid,
-            )
-            if self.video_saver_stop_event is not None:
-                self.video_saver_stop_event.set()
-            with self.condition:
-                self.condition.notify_all()
-            self.video_saver.join(timeout=10)
-
+        if self.video_saver is not None:
             if self.video_saver.is_alive():
-                self.log.error(
-                    "Previous VideoSaver did not exit after timeout; terminating pid=%s",
+                self.log.warning(
+                    "Previous VideoSaver still alive; joining before spawning "
+                    "a new one. pid=%s",
                     self.video_saver.pid,
                 )
-                self.video_saver.terminate()
-                self.video_saver.join(timeout=5)
+                if self.video_saver_stop_event is not None:
+                    self.video_saver_stop_event.set()
+                with self.condition:
+                    self.condition.notify_all()
+                self.video_saver.join(timeout=10)
+
+                if self.video_saver.is_alive():
+                    self.log.error(
+                        "Previous VideoSaver did not exit after timeout; "
+                        "terminating pid=%s",
+                        self.video_saver.pid,
+                    )
+                    self.video_saver.terminate()
+                    self.video_saver.join(timeout=5)
+
+            saver_succeeded = self.video_saver.exitcode == 0
+            self._collect_finished_clip(wait_for_result=saver_succeeded)
 
         stop_event = Event()
         self.video_saver_stop_event = stop_event
@@ -910,6 +1146,7 @@ class MotionDetector:
                 event_id=clip_info.event_id,
                 event_start_ts=clip_info.event_start_ts,
                 part_number=clip_info.part_number,
+                part_start_ts=clip_info.part_start_ts,
                 cam_name=self.cam_name,
                 triggered_by=clip_info.originator,
             )
@@ -936,11 +1173,16 @@ class MotionDetector:
             cpu_h264=cpu_h264, 
             cpu_h264_bitrate=cpu_h264_bitrate,
             sonar=getattr(self, "sonar", False),
+            composite_mode=self.composite,
+            result_q=self.result_q,
             **vs_kwargs,
         )
 
         video_saver.start()
         self.video_saver = video_saver
+        if clip_info is not None and self.composite:
+            key = (clip_info.event_id, clip_info.part_number)
+            self._video_saver_clip_infos[key] = clip_info
         self.motion_detected = True
         self.motion_counter = 0
 
@@ -968,11 +1210,22 @@ class MotionDetector:
         motion_trigger_seconds: float = 0.2, # Seconds of motion required to trigger detection
         warmup_seconds: float = 1.0,
         sonar: bool = False,
+        composite: Optional[bool] = None,
         shutdown_event=None,
     ):
         # When enabled, each completed motion clip gets a matching JSON file in
         # <device_root>/device_settings/ for downstream sonar processing.
         self.sonar = bool(sonar)
+        if composite is not None:
+            self.composite = bool(composite)
+        if self.composite and (
+            self.coordinator is None or self.cam_name is None
+            or self.composite_queue is None
+        ):
+            raise ValueError(
+                "Composite mode requires multi-camera coordinator, cam_name, "
+                "and composite_queue"
+            )
 
         if morph_kernel_size < 1:
             raise ValueError("morph_kernel_size must be >= 1")
@@ -1022,14 +1275,19 @@ class MotionDetector:
         cont_dir = os.path.join(self.save_folder, 'cont_vids')
         Path(cont_dir).mkdir(parents=True, exist_ok=True)
 
-        if staging:
-            motion_dir = os.path.join(self.save_folder, MOTION_VIDS_STAGING)
+        target_motion_dir_name = MOTION_VIDS_STAGING if staging else MOTION_VIDS
+        target_motion_dir = os.path.join(self.save_folder, target_motion_dir_name)
+        if self.composite:
+            motion_dir = os.path.join(self.save_folder, MOTION_VIDS_PARTS)
         else:
-            motion_dir = os.path.join(self.save_folder, MOTION_VIDS)
+            motion_dir = target_motion_dir
         Path(motion_dir).mkdir(parents=True, exist_ok=True)
+        Path(target_motion_dir).mkdir(parents=True, exist_ok=True)
 
         ensure_writable_dir(cont_dir, "continuous video")
         ensure_writable_dir(motion_dir, "motion video")
+        if self.composite:
+            ensure_writable_dir(target_motion_dir, "composite motion video")
 
         cur_clip = self.dataloader.next_clip()
         self.frame_log[cur_clip.name] = []
@@ -1444,6 +1702,7 @@ class MotionDetector:
                     elapsed_time = (end_time - start_time) * 1000
                     self.log.info(f"Time elapsed: {elapsed_time:.2f} ms")
                     utils.ping_in_background(self.ping_url)
+                    self._enqueue_stale_composites()
                 frame_counter += 1
         finally:
             try:
@@ -1481,6 +1740,12 @@ class MotionDetector:
             if video_saver and video_saver.is_alive():
                 try:
                     video_saver.join()
+                    self._collect_finished_clip(wait_for_result=True)
                 except Exception:
                     self.log.exception("video_saver.join raised")
+            else:
+                try:
+                    self._collect_finished_clip()
+                except Exception:
+                    self.log.exception("collecting final VideoSaver result raised")
         return self.frame_log

--- a/training/tools/run_motion_detect_rtsp.py
+++ b/training/tools/run_motion_detect_rtsp.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from pysalmcount import videoloader as vl
 from pysalmcount import motion_detect_stream as md
+from pysalmcount import clip_compositor as cc
 
 import argparse
 import os
@@ -186,6 +187,7 @@ def _run_detector_in_thread(det, fps, algo, orin, raspi, staging, cam_name, stat
         motion_trigger_seconds,
         warmup_seconds,
         sonar,
+        composite,
     ):
     """Run one camera and report exactly one terminal result."""
     try:
@@ -203,6 +205,7 @@ def _run_detector_in_thread(det, fps, algo, orin, raspi, staging, cam_name, stat
                 warmup_seconds=warmup_seconds,
                 shutdown_event=shutdown_event,
                 sonar=sonar,
+                composite=composite,
                 )
     except Exception as exc:
         logger.exception("[%s] detector thread crashed", cam_name)
@@ -215,28 +218,69 @@ def _run_detector_in_thread(det, fps, algo, orin, raspi, staging, cam_name, stat
             status_queue.put((cam_name, None))
 
 
-def _shutdown_on_camera_termination(status_queue, shutdown_event, threads):
-    """Stop every camera after the first terminates, then fail the process."""
-    cam_name, error = status_queue.get()
-    if error is None:
-        logger.critical(
-            "[%s] detector stopped unexpectedly; stopping all cameras",
-            cam_name,
-        )
-    else:
-        logger.critical(
-            "[%s] detector failed with %s: %s; stopping all cameras",
-            cam_name,
-            type(error).__name__,
-            error,
-        )
+def _stop_compositor(coordinator, composite_queue, compositor_worker):
+    if compositor_worker is None or composite_queue is None:
+        return
+    if compositor_worker.pid is None:
+        return
+    if not compositor_worker.is_alive():
+        compositor_worker.join(timeout=0)
+        return
 
-    # Each detector observes this in its normal run loop and exits through the
-    # same finally block as single-camera mode. That closes its VideoLoader,
-    # stops/joins its VideoSaver, and releases its continuous VideoWriter.
-    shutdown_event.set()
-    for thread in threads:
-        thread.join()
+    if coordinator is not None:
+        for job in coordinator.reap_stale_parts(force=True):
+            logger.warning(
+                "Flushing incomplete event=%s part=%d during shutdown",
+                job.event_id,
+                job.part_number,
+            )
+            composite_queue.put(job)
+    composite_queue.put(None)
+    compositor_worker.join(timeout=md.COMPOSITE_TIMEOUT_SECONDS)
+    if compositor_worker.is_alive():
+        logger.error(
+            "Compositor did not drain within %.1fs; terminating worker. "
+            "Unprocessed source clips remain recoverable in %s/",
+            md.COMPOSITE_TIMEOUT_SECONDS,
+            md.MOTION_VIDS_PARTS,
+        )
+        compositor_worker.terminate()
+        compositor_worker.join(timeout=5)
+
+
+def _shutdown_on_camera_termination(
+    status_queue,
+    shutdown_event,
+    threads,
+    coordinator=None,
+    composite_queue=None,
+    compositor_worker=None,
+):
+    """Stop every camera after the first terminates, then fail the process."""
+    cam_name = None
+    error = None
+    try:
+        cam_name, error = status_queue.get()
+        if error is None:
+            logger.critical(
+                "[%s] detector stopped unexpectedly; stopping all cameras",
+                cam_name,
+            )
+        else:
+            logger.critical(
+                "[%s] detector failed with %s: %s; stopping all cameras",
+                cam_name,
+                type(error).__name__,
+                error,
+            )
+    finally:
+        # Each detector observes this in its normal run loop and exits through
+        # the same finally block as single-camera mode. That closes its loader,
+        # stops/joins its saver, and releases its continuous writer.
+        shutdown_event.set()
+        for thread in threads:
+            thread.join()
+        _stop_compositor(coordinator, composite_queue, compositor_worker)
 
     if error is not None:
         raise error
@@ -270,14 +314,67 @@ def main(args):
 
     if args.multi_camera:
         urls, cam_names = _parse_multi_camera_args(args)
+        composite = not args.no_composite
         logger.info(
-            "Multi-camera mode: %d cameras, names=%s", len(urls), cam_names
+            "Multi-camera mode: %d cameras, names=%s, composite=%s",
+            len(urls),
+            cam_names,
+            composite,
         )
+
+        canonical_save_prefix = save_prefix or os.uname()[1]
+        composite_queue = None
+        compositor_worker = None
+        if composite:
+            if args.sonar:
+                logger.warning(
+                    "Sonar calibration is not meaningful on vertically stacked "
+                    "multi-camera frames because y_percent spans multiple views"
+                )
+            parts_dir = site_save_path / md.MOTION_VIDS_PARTS
+            output_dir = site_save_path / (
+                md.MOTION_VIDS_STAGING if args.staging else md.MOTION_VIDS
+            )
+            parts_dir.mkdir(parents=True, exist_ok=True)
+            output_dir.mkdir(parents=True, exist_ok=True)
+            md.ensure_writable_dir(parts_dir, "motion video parts")
+            md.ensure_writable_dir(output_dir, "composite motion video")
+
+            composite_queue = mp.Queue()
+            recovered_jobs = cc.find_stale_composite_jobs(
+                parts_dir=parts_dir,
+                cam_names=cam_names,
+                out_dir=output_dir,
+                save_prefix=canonical_save_prefix,
+                fps=fps,
+                sonar=args.sonar,
+                stale_after_seconds=md.COMPOSITE_TIMEOUT_SECONDS,
+            )
+            for job in recovered_jobs:
+                logger.warning(
+                    "Queueing recovered event=%s part=%d from %s/",
+                    job.event_id,
+                    job.part_number,
+                    md.MOTION_VIDS_PARTS,
+                )
+                composite_queue.put(job)
+            compositor_worker = cc.CompositorWorker(composite_queue)
 
         # Share ONE coordinator across all cam threads. Timing defaults come
         # from the module-level constants in motion_detect_stream.py; changing
         # those constants automatically applies to both single- and multi-cam.
-        coordinator = md.MotionEventCoordinator(cam_names)
+        coordinator = md.MotionEventCoordinator(
+            cam_names,
+            composite_out_dir=(
+                site_save_path / (
+                    md.MOTION_VIDS_STAGING if args.staging else md.MOTION_VIDS
+                )
+                if composite else None
+            ),
+            composite_save_prefix=(canonical_save_prefix if composite else None),
+            composite_fps=(fps if composite else None),
+            composite_sonar=args.sonar,
+        )
         status_queue = queue.Queue()
         shutdown_event = threading.Event()
 
@@ -297,7 +394,8 @@ def main(args):
                 camera_backend=args.camera_backend,
             )
             cam_save_prefix = (
-                f"{save_prefix}_{cam_name}" if save_prefix is not None else cam_name
+                f"{save_prefix}_{cam_name}"
+                if save_prefix is not None else cam_name
             )
             det = md.MotionDetector(
                 dataloader=vidloader,
@@ -308,37 +406,58 @@ def main(args):
                 is_video=is_video,
                 coordinator=coordinator,
                 cam_name=cam_name,
+                composite=composite,
+                composite_queue=composite_queue,
             )
             detectors.append((det, cam_name))
 
         threads = []
-        for det, cam_name in detectors:
-            t = threading.Thread(
-                target=_run_detector_in_thread,
-                args=(
-                    det, fps, args.algo, args.orin, args.raspi, 
-                    args.staging, cam_name, status_queue,
-                    shutdown_event, args.cpu_h264, args.bitrate,
-                    args.bgsub_threshold,
-                    args.cnt_min_pixel_stability,
-                    args.cnt_max_pixel_stability,
-                    args.fg_threshold,
-                    args.morph_kernel_size,
-                    args.erode_iter,
-                    args.dilate_iter,
-                    args.min_contour_area,
-                    args.min_contour_area_ratio,
-                    args.motion_trigger_seconds,
-                    args.warmup_seconds,
-                    args.sonar,
-                ),
-                name=f"MotionDetector-{cam_name}",
-                daemon=False,
-            )
-            t.start()
-            threads.append(t)
+        try:
+            if compositor_worker is not None:
+                compositor_worker.start()
 
-        _shutdown_on_camera_termination(status_queue, shutdown_event, threads)
+            for det, cam_name in detectors:
+                t = threading.Thread(
+                    target=_run_detector_in_thread,
+                    args=(
+                        det, fps, args.algo, args.orin, args.raspi,
+                        args.staging, cam_name, status_queue,
+                        shutdown_event, args.cpu_h264, args.bitrate,
+                        args.bgsub_threshold,
+                        args.cnt_min_pixel_stability,
+                        args.cnt_max_pixel_stability,
+                        args.fg_threshold,
+                        args.morph_kernel_size,
+                        args.erode_iter,
+                        args.dilate_iter,
+                        args.min_contour_area,
+                        args.min_contour_area_ratio,
+                        args.motion_trigger_seconds,
+                        args.warmup_seconds,
+                        args.sonar,
+                        composite,
+                    ),
+                    name=f"MotionDetector-{cam_name}",
+                    daemon=False,
+                )
+                t.start()
+                threads.append(t)
+
+            _shutdown_on_camera_termination(
+                status_queue,
+                shutdown_event,
+                threads,
+                coordinator=coordinator,
+                composite_queue=composite_queue,
+                compositor_worker=compositor_worker,
+            )
+        except BaseException:
+            shutdown_event.set()
+            for thread in threads:
+                if thread.is_alive():
+                    thread.join()
+            _stop_compositor(coordinator, composite_queue, compositor_worker)
+            raise
 
     # --- Single-camera path (today's behavior) ---
     input_str = _build_input_str(args.input, args.gstreamer, args.h265)
@@ -424,16 +543,25 @@ if __name__ == "__main__":
             "Enable multi-camera mode. The positional input is then treated "
             "as a comma-separated list of RTSP URLs (N >= 2). All cameras "
             "share lock-step clip boundaries (same event_id, same "
-            "part_number count, same wall-clock length) via a coordinator."
+            "part_number count, same wall-clock length) via a coordinator "
+            "and are vertically composited by default."
         ),
     )
     parser.add_argument(
         "--cam-names", default=None, dest='cam_names',
         help=(
-            "Comma-separated camera names used to disambiguate clips in "
-            "multi-camera mode. Each name must match [A-Za-z0-9_-]+, no "
-            "duplicates. Length must equal the number of RTSP URLs in the "
-            "positional input. Defaults to cam1,cam2,...,camN."
+            "Comma-separated camera names in top-to-bottom composite order. "
+            "Each name must match [A-Za-z0-9_-]+, no duplicates. Length must "
+            "equal the number of RTSP URLs in the positional input. Defaults "
+            "to cam1,cam2,...,camN."
+        ),
+    )
+    parser.add_argument(
+        "--no-composite",
+        action="store_true",
+        help=(
+            "In multi-camera mode, retain separate per-camera motion clips "
+            "instead of vertically stacking them"
         ),
     )
     parser.add_argument(

--- a/utils/jetson/salmonmd/README.md
+++ b/utils/jetson/salmonmd/README.md
@@ -5,3 +5,34 @@ motion detected videos to a specified folder (likely an external drive) using
 the hostname of the device to demarcate folder structure.
 
 Similar instructions to [Raspi's motion detection](../../pi/services).
+
+## Multi-camera motion clips
+
+Set `RTSP_URL` to a comma-separated list of camera URLs and add
+`--multi-camera` to `FLAGS`. Use `--cam-names` to assign camera identities; its
+order must match `RTSP_URL` and determines the top-to-bottom order in the
+composite.
+
+For example:
+
+```dotenv
+RTSP_URL=rtsp://192.168.1.88/0,rtsp://192.168.1.89/0,rtsp://192.168.1.90/0
+FLAGS=--cpu_h264 --multi-camera --cam-names left,middle,right --url 'https://google.com'
+```
+
+Multi-camera motion clips are vertically composited by default. Each camera is
+recorded independently into `motion_vids_parts/`, with temporary metadata in
+`motion_vids_parts_metadata/`. After every available row for an event part is
+combined successfully, the canonical composite is written to `motion_vids/`
+(or `motion_vids_staging/` with `--staging`) and the corresponding intermediate
+files are removed.
+
+For three 1280x720 rows, the output is a 1280x2160 H.264 MP4 named:
+
+```text
+{orgid}-{site}-{device}_{YYYYMMDD_HHMMSS}_M.mp4
+```
+
+Only the final file under `motion_vids/` follows the normal cloud sync path;
+the intermediate directories are not uploaded. Use `--no-composite` to retain
+separate per-camera motion clips instead.

--- a/utils/jetson/salmonmd/README.md
+++ b/utils/jetson/salmonmd/README.md
@@ -33,6 +33,12 @@ For three 1280x720 rows, the output is a 1280x2160 H.264 MP4 named:
 {orgid}-{site}-{device}_{YYYYMMDD_HHMMSS}_M.mp4
 ```
 
+Before stacking, the compositor probes each available source's frame count and
+aligns the clip endings. The shortest source determines the common output frame
+count, and excess frames are removed from the beginning of longer sources. A
+missing camera retains its configured row as black video for that common
+duration.
+
 Only the final file under `motion_vids/` follows the normal cloud sync path;
 the intermediate directories are not uploaded. Use `--no-composite` to retain
 separate per-camera motion clips instead.

--- a/utils/jetson/salmonmd/template.env
+++ b/utils/jetson/salmonmd/template.env
@@ -39,7 +39,10 @@ FLAGS=--cpu_h264 --url 'https://google.com'
 # --- Multi-camera mode (optional) ---------------------------------------
 # Set RTSP_URL to a comma-separated list of >= 2 RTSP URLs and add the
 # `--multi-camera` flag (plus optional `--cam-names`) to FLAGS to run N cameras in
-# one container.
+# one container. Multi-camera motion clips are vertically composited by default;
+# `--cam-names` order is the top-to-bottom row order. Keep RTSP_URL in that same
+# order: swapping an IP in RTSP_URL silently reorders the composite rows.
+# Add `--no-composite` to retain separate per-camera motion clips instead.
 # Example:
 #   RTSP_URL=rtsp://192.168.1.88/0,rtsp://192.168.1.89/0,rtsp://192.168.1.90/0
 #   FLAGS=--cpu_h264 --multi-camera --cam-names cam1,cam2,cam3 --url 'https://google.com'


### PR DESCRIPTION
Adds multi-camera support that records per-camera parts and (by default) vertically stacks them into a single composite video aligned by clip-ends. Implements a new ffmpeg-based compositor, integrates it into the motion detector pipeline, adds CLI flags to enable/disable compositing.

- New compositor: training/pysalmcount/pysalmcount/clip_compositor.py
  - CompositeJob/CompositeSource dataclasses, ffmpeg command builder, alignment by clip-ends, CompositorWorker (serialize ffmpeg work), and recovery utilities (find_stale_composite_jobs).
- Integrates compositing into the motion pipeline:
  - MotionEventCoordinator: added constructor parameters for composite_out_dir, save_prefix, fps, sonar, and timeout; new methods _build_composite_job, report_part_finished, and reap_stale_parts to manage part-level aggregation and timeouts.
  - VideoSaver / MotionDetector: support for composite_mode and a result queue; finished per-camera parts are forwarded to the coordinator and, when complete (or timed out), composite jobs are emitted to the compositor queue.
  - run_motion_detect_rtsp: multi-camera startup/shutdown, recovered-job queuing at startup, compositor worker lifecycle, and graceful shutdown/flush.
- Metadata and filenames:
  - part_start_ts added to ClipInfo and propagated to metadata and filenames when in composite mode.
  - Per-part metadata is written to motion_vids_parts_metadata/; final composites are written to motion_vids/ or motion_vids_staging/.
  - Metadata payloads include part_start_ts, pre_roll_frames and other probe data for the composite output.